### PR TITLE
Setup Quick Switch Shortcuts

### DIFF
--- a/app/components/gh-switcher.js
+++ b/app/components/gh-switcher.js
@@ -9,10 +9,33 @@ const {Component} = Ember;
 export default Component.extend({
     store: Ember.inject.service(),
     classNames: ['switcher'],
+    shortcuts: [],
 
     didRender() {
         this._super(...arguments);
         this._setupContextMenu();
+        this._setupQuickSwitch();
+    },
+
+    /**
+     * Setups the shortcut handling
+     */
+    _setupQuickSwitch() {
+        let {remote} = requireNode('electron');
+        let {globalShortcut} = remote;
+
+        // Cleanup
+        globalShortcut.unregisterAll();
+
+        // Register shortcuts for each blog
+        this.get('blogs')
+            .slice(0, 8)
+            .map((blog, i) => {
+                let sc = `CmdOrCtrl+${i + 1}`;
+
+                globalShortcut.unregister(sc);
+                globalShortcut.register(sc, () => this.send('switchToBlog', blog));
+            });
     },
 
     /**

--- a/app/helpers/switch-shortcut.js
+++ b/app/helpers/switch-shortcut.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export function switchShortcut(params) {
+    let index = (params && params[0]) ? params[0] + 1 : 1;
+    let cmdOrCtrl = (process.platform && process.platform === 'darwin') ? '⌘' : 'Ctrl';
+
+    // If bigger than 9, don't return anything
+    return (index > 9) ? '' : `${cmdOrCtrl} ${index}`;
+}
+
+export default Ember.Helper.helper(switchShortcut);

--- a/app/templates/components/gh-switcher.hbs
+++ b/app/templates/components/gh-switcher.hbs
@@ -4,7 +4,7 @@
             <div class="switch-btn" {{action "switchToBlog" blog}} data-blog={{blog.id}}>
                 <span>{{first-letter blog.name}}</span>
             </div>
-            <div class="switch-shortcut">⌘{{index}}</div>
+            <div class="switch-shortcut">{{switch-shortcut index}}</div>
         </div>
     {{/each}}
 </div>

--- a/tests/integration/components/gh-add-blog-test.js
+++ b/tests/integration/components/gh-add-blog-test.js
@@ -145,7 +145,7 @@ test('does not create a record for an unreachable url', function(assert) {
     const qAsync = assert.async();
     this.render(hbs`{{gh-add-blog}}`);
 
-    this.$('input[name="url"]').val('https://imnotreachableever.tld');
+    this.$('input[name="url"]').val('https://0.0.0.0:1111/');
     this.$('input[name="url"]').change();
     this.$('input[name="identification"]').val('test@user.com');
     this.$('input[name="identification"]').change();

--- a/tests/integration/components/gh-switcher-test.js
+++ b/tests/integration/components/gh-switcher-test.js
@@ -40,14 +40,18 @@ moduleForComponent('gh-switcher', 'Integration | Component | gh switcher', {
  */
 
 test('it renders', function(assert) {
-    this.render(hbs`{{gh-switcher}}`);
+    this.set('_blogs', []);
+    this.render(hbs`{{gh-switcher blogs=_blogs}}`);
     assert.equal(this.$().text().trim(), '+');
 });
 
 test('it renders all blogs as single-letter buttons', function(assert) {
     this.set('_blogs', blogs);
     this.render(hbs`{{gh-switcher blogs=_blogs}}`);
-    assert.equal(this.$().text().trim().replace(/(\r\n|\n|\r| )/gm,''), 'T⌘0T⌘1T⌘2+');
+    
+    let expected = (process.platform === 'darwin') ? 'T⌘1T⌘2T⌘3+' : 'TCtrl1TCtrl2TCtrl3+';
+    
+    assert.equal(this.$().text().trim().replace(/(\r\n|\n|\r| )/gm,''), expected);
 });
 
 test('it renders all blogs with the id in the data attribute', function(assert) {

--- a/tests/unit/helpers/switch-shortcut-test.js
+++ b/tests/unit/helpers/switch-shortcut-test.js
@@ -1,0 +1,17 @@
+import { switchShortcut } from 'ghost-desktop/helpers/switch-shortcut';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | switch shortcut');
+
+test('starts at 1 for 0', function(assert) {
+    let result = switchShortcut([0]);
+    let ok = result.includes('1');
+
+    assert.ok(ok);
+});
+
+test('does not return anything for indexes larger than 8', function(assert) {
+    let result = switchShortcut([9]);
+
+    assert.equal(result, '');
+});


### PR DESCRIPTION
- Adds “quick switch” functionality, enabling users to switch back and forth between blogs by using Ctrl / Cmd and the index (starting from 1)

Closes #4