### PR TITLE
Fixes a cosmetic issue where removing all blogs presents the user with a blank screen.

### DIFF
--- a/app/components/gh-app.js
+++ b/app/components/gh-app.js
@@ -14,11 +14,9 @@ export default Component.extend({
     /**
      * Boolean value that returns true if there are any blogs
      */
-    hasBlogs: Ember.computed('blogs', {
-        get() {
-            let b = this.get('blogs');
-            return (b && b.content && b.content.length && b.content.length > 0);
-        }
+    hasBlogs: Ember.computed('blogs', function () {
+        let b = this.get('blogs');
+        return (b && b.content && b.content.length && b.content.length > 0);
     }),
 
     /**


### PR DESCRIPTION
Fixes #65 ! For whatever reason, the computed property wasn't getting updated when the `blogs` property was set to an empty list. Making it a simple computed property getter fixes the issue.

Please include a description of your change & check your PR against this list, thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `npm test`).

More info can be found by clicking the "guidelines for contributing" link above.