### PR TITLE
Disables web security on the guest webview to prevent mixed content errors.

### DIFF
--- a/app/templates/components/gh-instance-host.hbs
+++ b/app/templates/components/gh-instance-host.hbs
@@ -1,4 +1,4 @@
-<webview src="{{blog.url}}" class="host {{if isInstanceLoaded "loaded"}}" allowpopups preload="../main/preload.js"></webview>
+<webview src="{{blog.url}}" class="host {{if isInstanceLoaded "loaded"}}" allowpopups disablewebsecurity preload="../main/preload.js"></webview>
 
 <div class="gh-app">
         <div class="gh-loading-side"></div>


### PR DESCRIPTION
Fixes #66 by disabling web security (thus enabling http/https content mixing) on the guest webview.