### PR TITLE
Decodes html entities in window title

### DIFF
--- a/app/models/blog.js
+++ b/app/models/blog.js
@@ -11,7 +11,7 @@ export default DS.Model.extend({
     identification: attr('string'),
     isSelected: attr('boolean'),
     iconColor: attr('string', {
-        defaultValue: () => getIconColor()
+        defaultValue: () => getIconColor(null)
     }),
 
     /**
@@ -41,8 +41,8 @@ export default DS.Model.extend({
     /**
      * Convenience method, generates a nice icon color for this blog.
      */
-    randomIconColor() {
-        this.set('iconColor', getIconColor());
+    randomIconColor(excluding=null) {
+        this.set('iconColor', getIconColor(excluding));
     },
 
     /**

--- a/app/utils/color-picker.js
+++ b/app/utils/color-picker.js
@@ -6,7 +6,7 @@ const ColorScheme = require('color-scheme');
  * @export
  * @return {string}
  */
-export default function getIconColor() {
+export default function getIconColor(excludedColor) {
     let scheme = new ColorScheme();
 
     // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
@@ -17,6 +17,19 @@ export default function getIconColor() {
     // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
 
     let colors = scheme.colors();
+
+    // Make sure our generated colors don't contain the color
+    // that's already set.
+    if (excludedColor !== null) {
+        // We store colors on the model with the '#' prefixed.
+        let colorName = excludedColor.substr(1);
+        let excludedColorIndex = colors.indexOf(colorName);
+
+        if (excludedColorIndex >= 0) {
+            colors.removeAt(excludedColorIndex);
+        }
+    }
+
     let index = Math.floor(Math.random() * colors.length);
 
     return ['#', colors[index]].join('');

--- a/app/utils/set-window-title.js
+++ b/app/utils/set-window-title.js
@@ -1,3 +1,4 @@
+const he = require('he');
 
 /**
  * Sets the title on the currently focussed Window (or the first found window)
@@ -9,9 +10,10 @@ export default function setWindowTitle(title = 'Ghost') {
     let {remote} = requireNode('electron');
     let {BrowserWindow} = remote;
     let currentWindow = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
+    let decodedTitle = he.decode(title);
 
     // We should always have only one Window
     if (currentWindow) {
-        currentWindow.setTitle(`Ghost - ${title}`);
+        currentWindow.setTitle(`Ghost - ${decodedTitle}`);
     }
 }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "dependencies": {
     "color-scheme": "0.0.5",
     "electron-window-state": "^2.0.0",
+    "he": "^0.5.0",
     "hexrgb": "0.0.2",
     "keytar": "^3.0.0"
   }

--- a/tests/unit/models/blog-test.js
+++ b/tests/unit/models/blog-test.js
@@ -78,8 +78,6 @@ test('it can generate a new random icon color', function (assert) {
     let blog = this.subject();
     let oldColor = blog.get('iconColor');
 
-    Ember.run(() => blog.randomIconColor());
-
-    debugger;
+    Ember.run(() => blog.randomIconColor(excluding=oldColor));
     assert.notEqual(oldColor, blog.get('iconColor'));
 });

--- a/tests/unit/utils/color-picker-test.js
+++ b/tests/unit/utils/color-picker-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module ('Unit | Utility | get icon color');
 
 test('it generates a color for the icon', function (assert) {
-    let color = getIconColor();
+    let color = getIconColor(null);
 
     assert.ok(
       /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(color)

--- a/tests/unit/utils/set-window-title-test.js
+++ b/tests/unit/utils/set-window-title-test.js
@@ -1,11 +1,14 @@
 import setWindowTitle from 'ghost-desktop/utils/set-window-title';
 import { module, test } from 'qunit';
 
+const he = require('he');
+
 module('Unit | Utility | set window title');
 
 test('it sets the window title', function(assert) {
     let oldRequire = window.requireNode;
-    let newTitle = 'Testtitle'
+    let newTitle = 'bhargav&apos;s cool blog';
+    let decodedTitle = he.decode(newTitle);
 
     window.requireNode = function (module) {
         if (module === 'electron') {
@@ -15,7 +18,7 @@ test('it sets the window title', function(assert) {
                         getFocusedWindow() {
                             return {
                                 setTitle(title) {
-                                    assert.equal(title, `Ghost - ${newTitle}`);
+                                    assert.equal(title, `Ghost - ${decodedTitle}`);
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes #85 

- Added a html entity decoding library.
- Using it to decode the title string, and setting it.
- Modified the existing setWindowTitle test.