### PR TITLE
Continue if keytar fails

### DIFF
--- a/app/models/blog.js
+++ b/app/models/blog.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import getIconColor from '../utils/color-picker';
+import requireKeytar from '../utils/require-keytar';
 
 /*eslint-disable no-unused-vars*/
 const {Model, attr, hasMany} = DS;
@@ -57,8 +58,8 @@ export default DS.Model.extend({
      * @param {string} value - Password to set
      */
     setPassword(value) {
-        let keytar = requireNode('keytar');
-        return keytar.replacePassword(this.get('url'), this.get('identification'), value);
+        let keytar = requireKeytar();
+        return (keytar ? keytar.replacePassword(this.get('url'), this.get('identification'), value) : false);
     },
 
     /**
@@ -71,7 +72,7 @@ export default DS.Model.extend({
             return null;
         }
 
-        let keytar = requireNode('keytar');
-        return keytar.getPassword(this.get('url'), this.get('identification'));
+        let keytar = requireKeytar();
+        return (keytar ? keytar.getPassword(this.get('url'), this.get('identification')) : null);
     }
 });

--- a/app/utils/require-keytar.js
+++ b/app/utils/require-keytar.js
@@ -1,0 +1,16 @@
+
+/**
+ * Attempts to require keytar, returns false if it fails
+ *
+ */
+export default function requireKeytar() {
+    let keytar = null;
+
+    try {
+        keytar = requireNode('keytar');
+    } catch (e) {
+        keytar = false;
+    }
+
+    return keytar;
+}

--- a/tests/unit/utils/require-keytar-test.js
+++ b/tests/unit/utils/require-keytar-test.js
@@ -1,0 +1,26 @@
+import requireKeytar from 'ghost-desktop/utils/require-keytar';
+import {module, test} from 'qunit';
+
+module('Unit | Utility | require keytar');
+
+test('it returns the keytar module', function(assert) {
+    let result = requireKeytar();
+    assert.ok(result);
+});
+
+test('it returns false when require keytar fails', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(module) {
+        if (module === 'keytar') {
+            throw new Error("Module loading error");
+        } else {
+            oldRequire(...arguments);
+        }
+    }
+
+    let result = requireKeytar();
+    assert.equal(result, false);
+
+    window.requireNode = oldRequire;
+});


### PR DESCRIPTION
* Wraps the keytar require in a try/catch. If it throws then return false, otherwise return the module.
* On setPassword return false if keytar fails
* On getPassword return null if keytar fails

(fixes #58)