### PR TITLE
Auto Updater (OS X)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
   - "npm install -g bower"
 
 install:
+  - rm -rf ./node_modules
   - npm install
   - bower install
   - export DISPLAY=':99.0'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,7 +101,7 @@ const configureGrunt = function(grunt) {
     
     grunt.initConfig(config);
     
-    grunt.registerTask('codestyle', 'Test Code Style', ['eslint', , 'jscs:app']);
+    grunt.registerTask('codestyle', 'Test Code Style', ['eslint', 'jscs:app']);
     grunt.registerTask('validate', 'Test Code Style and App', ['codestyle', 'shell:test', 'shell:logCoverage']);
     grunt.registerTask('build', 'Compile Ghost Desktop for the current platform', ['shell:build']);
     grunt.registerTask('installer-32', ['clean:builds32', 'shell:build32', 'create-windows-installer:ia32'])

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,10 +55,10 @@ const configureGrunt = function(grunt) {
                 command: 'ember electron:test'
             },
             build: {
-                command: `ember electron:package --arch x64 --platform ${process.platform} --app-version ${package.version} --overwrite`
+                command: `ember electron:package --environment production --arch x64 --platform ${process.platform} --app-version ${package.version} --overwrite`
             },
             build32: {
-                command: `ember electron:package --arch ia32 --platform ${process.platform} --app-version ${package.version} --overwrite`
+                command: `ember electron:package --environment production --arch ia32 --platform ${process.platform} --app-version ${package.version} --overwrite`
             },
             logCoverage: {
                 command: 'node ./scripts/log-coverage.js'
@@ -100,8 +100,9 @@ const configureGrunt = function(grunt) {
     };
     
     grunt.initConfig(config);
-
-    grunt.registerTask('validate', 'Test Code Style and App', ['eslint', 'jscs:app', 'shell:test', 'shell:logCoverage']);
+    
+    grunt.registerTask('codestyle', 'Test Code Style', ['eslint', , 'jscs:app']);
+    grunt.registerTask('validate', 'Test Code Style and App', ['codestyle', 'shell:test', 'shell:logCoverage']);
     grunt.registerTask('build', 'Compile Ghost Desktop for the current platform', ['shell:build']);
     grunt.registerTask('installer-32', ['clean:builds32', 'shell:build32', 'create-windows-installer:ia32'])
     grunt.registerTask('installer-64', ['clean:builds64', 'shell:build', 'create-windows-installer:x64'])

--- a/app/components/gh-app.js
+++ b/app/components/gh-app.js
@@ -8,11 +8,13 @@ const {Component} = Ember;
 
 export default Component.extend({
     store: Ember.inject.service(),
+    autoUpdate: Ember.inject.service(),
     classNames: ['gh-app'],
 
     didReceiveAttrs() {
         this.setup();
         this.createSingleInstance();
+        this.get('autoUpdate').checkForUpdates();
     },
 
     /**
@@ -29,8 +31,7 @@ export default Component.extend({
     setup() {
         if (this.get('hasBlogs')) {
             this.send('switchToBlog', this.findSelectedBlog() || this.get('blogs.firstObject'));
-            this.createDockMenu();
-            this.createUserTasks();
+            this.createMenus();
         } else {
             this.set('isEditBlogVisible', true);
         }
@@ -82,9 +83,12 @@ export default Component.extend({
     },
 
     /**
-     * Gets the current blogs and creates the dock menu
+     * Gets the current blogs and creates the various menus.
+     * On Windows: User Tasks (taskbar)
+     * On OS X: Dock Menu
+     * On all: Window Menu
      */
-    createDockMenu() {
+    createMenus() {
         let blogs = this.get('blogs');
         let menu = [];
 
@@ -98,24 +102,9 @@ export default Component.extend({
         if (process.platform === 'darwin') {
             setDockMenu(menu);
         }
-    },
-
-    /**
-     * Gets the current blogs and creates the user tasks array
-     */
-    createUserTasks() {
-        let blogs = this.get('blogs');
-        let tasks = [];
-
-        blogs.forEach((blog) => {
-            tasks.push({
-                name: blog.get('name'),
-                url: blog.get('url')
-            });
-        });
-
+        
         if (process.platform === 'win32') {
-            setUsertasks(tasks);
+            setUsertasks(menu);
         }
     },
 

--- a/app/components/gh-app.js
+++ b/app/components/gh-app.js
@@ -102,7 +102,7 @@ export default Component.extend({
         if (process.platform === 'darwin') {
             setDockMenu(menu);
         }
-        
+
         if (process.platform === 'win32') {
             setUsertasks(menu);
         }

--- a/app/components/gh-preferences.js
+++ b/app/components/gh-preferences.js
@@ -4,6 +4,7 @@ import fetchContributors from '../utils/fetch-contributors';
 export default Ember.Component.extend({
     classNames: ['gh-preferences'],
     preferences: Ember.inject.service(),
+    autoUpdate: Ember.inject.service(),
 
     didReceiveAttrs() {
         this._super(...arguments);
@@ -11,6 +12,8 @@ export default Ember.Component.extend({
         if (!this.get('preferences.contributors')) {
             fetchContributors().then((data) => this.set('preferences.contributors', data));
         }
+
+        this.get('autoUpdate').checkForUpdates();
     },
 
     actions: {

--- a/app/components/gh-switcher.js
+++ b/app/components/gh-switcher.js
@@ -8,6 +8,7 @@ const {Component} = Ember;
  */
 export default Component.extend({
     store: Ember.inject.service(),
+    windowMenu: Ember.inject.service(),
     classNames: ['switcher'],
 
     didRender() {
@@ -20,21 +21,19 @@ export default Component.extend({
      * Setups the shortcut handling
      */
     _setupQuickSwitch() {
-        let {remote} = requireNode('electron');
-        let {globalShortcut} = remote;
+        let blogMenuItems = [{type: 'separator'}];
 
-        // Cleanup leftover shortcuts - required for reloads and the such
-        globalShortcut.unregisterAll();
-
-        // Register shortcuts for each blog
         this.get('blogs')
             .slice(0, 8)
             .map((blog, i) => {
-                let sc = `CmdOrCtrl+${i + 1}`;
-
-                globalShortcut.unregister(sc);
-                globalShortcut.register(sc, () => this.send('switchToBlog', blog));
+                blogMenuItems.push({
+                    accelerator: `CmdOrCtrl+${i + 1}`,
+                    click: () => this.send('switchToBlog', blog),
+                    label: blog.get('name')
+                });
             });
+
+        this.get('windowMenu').addBlogsToMenu(blogMenuItems);
     },
 
     /**

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,7 +5,7 @@ const {Route} = Ember;
 
 export default Route.extend({
     windowMenu: Ember.inject.service(),
-    
+
     beforeModel() {
         this.get('windowMenu').setup();
         setupContextMenu();

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,12 +1,13 @@
 import Ember from 'ember';
-import { setup as setupWindowMenu } from '../utils/window-menu';
 import { setup as setupContextMenu } from '../utils/context-menu';
 
 const {Route} = Ember;
 
 export default Route.extend({
+    windowMenu: Ember.inject.service(),
+    
     beforeModel() {
-        setupWindowMenu();
+        this.get('windowMenu').setup();
         setupContextMenu();
     },
 

--- a/app/services/auto-update.js
+++ b/app/services/auto-update.js
@@ -1,0 +1,114 @@
+import Ember from 'ember';
+import ENV from 'ghost-desktop/config/environment';
+
+export default Ember.Service.extend(Ember.Evented, {
+    autoUpdater: null,
+    isCheckingForUpdate: null,
+    isUpdateAvailable: null,
+    isUpdateDownloaded: null,
+    isLatestVersion: null,
+    
+    /**
+     * Returns the current environment (testing, development, production)
+     */
+    environment: Ember.computed({
+        get() {
+            return ENV.environment;
+        }
+    }),
+    
+    /**
+     * Returns the current Ghost Desktop version, by querying the version
+     * defined in package.json. If that fails, it'll check the version of
+     * the current executable.
+     */
+    appVersion: Ember.computed({
+        get() {
+            let {remote} = requireNode('electron');
+            let appVersion = remote.require('app').getVersion();
+
+            return appVersion;
+        }
+    }),
+
+    /**
+     * Checks Ghost Desktop's update server for updates.
+     */
+    checkForUpdates() {
+        if (this.get('environment') !== 'production') {
+            return;
+        }
+
+        if (!this.get('autoUpdater')) {
+            this._setup();
+        }
+        
+        if (this.get('autoUpdater')) {
+            this.get('autoUpdater').checkForUpdates();
+        }
+    },
+
+    /**
+     * If an update has been downloaded, we update and shutdown.
+     * If not, we just shutdown.
+     */
+    updateAndShutdown() {
+        let {remote} = requireNode('electron');
+        let app = remote.require('app');
+        let autoUpdater = this.get('autoUpdater');
+
+        if (autoUpdater && this.get('isUpdateDownloaded')) {
+            autoUpdater.quitAndInstall();
+        } else {
+            app.quit();
+        }
+    },
+
+    /**
+     * Creates the autoUpdater, using Electorn's built-in auto-update module.
+     */
+    _setup() {
+        let {remote} = requireNode('electron');
+        let os = requireNode('os').platform();
+        let autoUpdater = remote.require('auto-updater');
+
+        // If we're not running signed code, requiring auto updater will fail
+        if (this.get('environment') !== 'production') {
+            return;
+        }
+        
+        // Todo: Handle Linux
+        let updateFeed = (os === 'darwin') ?
+            `http://desktop-updates.ghost.org/update/osx/${this.get('appVersion')}` :
+            `http://desktop-updates.ghost.org/update/win32/${this.get('appVersion')}`;
+
+        autoUpdater.setFeedURL(updateFeed);
+
+        autoUpdater.on('checking-for-update', () => {
+            this.set('isCheckingForUpdate', true);
+            this.trigger('checking-for-update');
+        });
+
+        autoUpdater.on('update-available', () => {
+            this.set('isCheckingForUpdate', false);
+            this.set('isUpdateAvailable', true);
+            this.trigger('update-available');
+        });
+
+        autoUpdater.on('update-downloaded', () => {
+            this.set('isCheckingForUpdate', false);
+            this.set('isUpdateAvailable', true);
+            this.set('isUpdateDownloaded', true);
+            this.trigger('update-downloaded');
+        });
+
+        autoUpdater.on('update-not-available', () => {
+            this.set('isCheckingForUpdate', false);
+            this.set('isUpdateAvailable', false);
+            this.set('isLatestVersion', true);
+            this.trigger('update-not-available');
+        });
+
+        this.set('autoUpdater', autoUpdater);
+    }
+});

--- a/app/services/auto-update.js
+++ b/app/services/auto-update.js
@@ -7,7 +7,7 @@ export default Ember.Service.extend(Ember.Evented, {
     isUpdateAvailable: null,
     isUpdateDownloaded: null,
     isLatestVersion: null,
-    
+
     /**
      * Returns the current environment (testing, development, production)
      */
@@ -16,7 +16,7 @@ export default Ember.Service.extend(Ember.Evented, {
             return ENV.environment;
         }
     }),
-    
+
     /**
      * Returns the current Ghost Desktop version, by querying the version
      * defined in package.json. If that fails, it'll check the version of
@@ -42,7 +42,7 @@ export default Ember.Service.extend(Ember.Evented, {
         if (!this.get('autoUpdater')) {
             this._setup();
         }
-        
+
         if (this.get('autoUpdater')) {
             this.get('autoUpdater').checkForUpdates();
         }
@@ -76,7 +76,7 @@ export default Ember.Service.extend(Ember.Evented, {
         if (this.get('environment') !== 'production') {
             return;
         }
-        
+
         // Todo: Handle Linux
         let updateFeed = (os === 'darwin') ?
             `http://desktop-updates.ghost.org/update/osx/${this.get('appVersion')}` :

--- a/app/services/window-menu.js
+++ b/app/services/window-menu.js
@@ -1,0 +1,80 @@
+import Ember from 'ember';
+import {setup as getMenuTemplate} from '../utils/window-menu';
+
+export default Ember.Service.extend({
+    autoUpdate: Ember.inject.service(),
+    blogs: [],
+
+    /**
+     * Setups the window menu for the application
+     */
+    setup() {
+        let {remote} = requireNode('electron');
+        let {Menu} = remote;
+        let template = getMenuTemplate();
+        let withBlogs = this._injectBlogs(template);
+        let withQuitHandler = this._injectQuitHandler(withBlogs);
+        let builtMenu = Menu.buildFromTemplate(withQuitHandler);
+
+        Menu.setApplicationMenu(builtMenu);
+    },
+
+    /**
+     * Adds blogs to the app's window menu
+     *
+     * @param blogs - An array of blogs to add to the menu.
+     */
+    addBlogsToMenu(blogs) {
+        if (blogs) {
+            this.set('blogs', blogs);
+            Ember.run.later(this, 'setup');
+        }
+    },
+
+    /**
+     * If blogs are present, they are injected into the menu
+     *
+     * @param template - Electron menu template
+     * @returns template - Electron menu template
+     */
+    _injectBlogs(template) {
+        let blogs = this.get('blogs');
+
+        if (template && template.forEach && blogs) {
+            template.forEach((item) => {
+                if (item && item.label && item.label === 'View') {
+                    item.submenu = item.submenu.concat(blogs);
+                }
+            });
+        }
+
+        return template;
+    },
+
+    /**
+     * If a quit handler is present, it is injected into the menu
+     *
+     * @param template - Electron menu template
+     * @returns template - Electron menu template
+     */
+    _injectQuitHandler(template) {
+        let self = this;
+
+        if (template && template.forEach) {
+            template.forEach((item) => {
+                if (item && item.label && item.label === 'Ghost') {
+                    item.submenu.forEach((subitem) => {
+                        if (subitem && subitem.label && subitem.label === 'Quit') {
+                            subitem.click = function click() {
+                                self.get('autoUpdate').updateAndShutdown();
+                            };
+                        }
+                    })
+                }
+            });
+        }
+
+        return template;
+    },
+
+});

--- a/app/services/window-menu.js
+++ b/app/services/window-menu.js
@@ -69,12 +69,11 @@ export default Ember.Service.extend({
                                 self.get('autoUpdate').updateAndShutdown();
                             };
                         }
-                    })
+                    });
                 }
             });
         }
 
         return template;
-    },
-
+    }
 });

--- a/app/templates/components/gh-preferences.hbs
+++ b/app/templates/components/gh-preferences.hbs
@@ -9,6 +9,22 @@
         <form id="settings-general">
             <fieldset>
                 <div class="form-group for-checkbox">
+                    <label>Automatic Updates</label>
+                    {{#if autoUpdate.isCheckingForUpdate}}
+                        <p>Ghost is currently looking for updates.</p>
+                    {{else if autoUpdate.isUpdateAvailable}}
+                        <p>An Update is available and is currently being downloaded. Once downloaded, it will automatically be installed the next time you start Ghost Desktop.</p>
+                    {{else if autoUpdate.isUpdateDownloaded}}
+                        <p>An Update was downloaded and will automatically be installed the next time you start Ghost Desktop.</p>
+                        <button {{action "installUpdate"}} type="button" class="btn btn-green">Install Update Now</button>
+                    {{else if autoUpdate.isLatestVersion}}
+                        <p>You're running the latest version of Ghost Desktop!</p>
+                    {{else}}
+                        <p>Ghost will periodically check for updates and automatically install new versions.</p>
+                    {{/if}}
+                    <p>You are currently running Ghost Desktop <strong>{{autoUpdate.appVersion}}</strong>.</p>
+                </div>
+                <div class="form-group for-checkbox">
                     <label for="isNotificationsEnabled">Enable notifications</label>
                     <label class="checkbox" for="isNotificationsEnabled">
                         {{input id="isNotificationsEnabled" type="checkbox" checked=preferences.isNotificationsEnabled}}

--- a/app/utils/window-menu.js
+++ b/app/utils/window-menu.js
@@ -93,7 +93,8 @@ export function openRepository() {
  */
 export function setup() {
     let {remote} = requireNode('electron');
-    let {Menu, app} = remote;
+    let {app} = remote;
+
     let template = [
         {
             label: 'Edit',
@@ -249,6 +250,8 @@ export function setup() {
                     label: 'Quit',
                     accelerator: 'Command+Q',
                     click() {
+                        // This is later overwritten to update,
+                        // if an update is required.
                         app.quit();
                     }
                 }
@@ -256,7 +259,5 @@ export function setup() {
         });
     }
 
-    let builtMenu = Menu.buildFromTemplate(template);
-    Menu.setApplicationMenu(builtMenu);
-    return builtMenu;
+    return template;
 }

--- a/main/entry.js
+++ b/main/entry.js
@@ -1,13 +1,13 @@
 /* jshint node: true */
 'use strict';
 
-const electron         = require('electron');
-const checkForUpdate   = require('./basic-update');
-const fetchWindowState = require('./window-state');
-const app              = electron.app;
-const BrowserWindow    = electron.BrowserWindow;
-const globalShortcut   = electron.globalShortcut;
-const emberAppLocation = `file://${__dirname}/../dist/index.html`;
+const electron             = require('electron');
+const checkForBetaUpdate   = require('./basic-update');
+const fetchWindowState     = require('./window-state');
+const app                  = electron.app;
+const BrowserWindow        = electron.BrowserWindow;
+const globalShortcut       = electron.globalShortcut;
+const emberAppLocation     = `file://${__dirname}/../dist/index.html`;
 
 
 // Before we do anything else, handle Squirrel Events
@@ -16,11 +16,13 @@ if (require('./squirrel')) {
 }
 
 let mainWindow = null;
-electron.crashReporter.start();
 
 app.on('ready', function onReady() {
     let windowState, usableState, stateKeeper;
-
+    
+    // Greetings
+    console.log('Welcome to Ghost 👻');
+    
     // Instantiate the window with the existing size and position.
     try {
         windowState = fetchWindowState();
@@ -28,12 +30,16 @@ app.on('ready', function onReady() {
         stateKeeper = windowState.stateKeeper;
 
         mainWindow = new BrowserWindow(
-            Object.assign(usableState, {show:false})
+            Object.assign(usableState, {show: false})
         );
     } catch (error) {
         // Window state keeper failed, let's still open a window
         console.log(error);
-        mainWindow = new BrowserWindow({show:false});
+        mainWindow = new BrowserWindow({
+            show: false,
+            height: 800,
+            width: 1000
+        });
     }
 
 
@@ -64,6 +70,6 @@ app.on('ready', function onReady() {
     if (process.platform === 'win32') {
         globalShortcut.register('Ctrl+Shift+I', () => mainWindow.toggleDevTools());
     }
-
-    checkForUpdate();
+    
+    checkForBetaUpdate();
 });

--- a/main/squirrel.js
+++ b/main/squirrel.js
@@ -4,9 +4,9 @@
  * ⚠ Remember: It needs to load ASAP, execute ASAP, exit ASAP! ⚠
  */
 
-const path = require('path');
-const spawn = require('child_process').spawn;
-const app = require('app');
+const path        = require('path');
+const spawn       = require('child_process').spawn;
+const app         = require('app');
 
 function run(args, done) {
     let updateExe = path.resolve(path.dirname(process.execPath), '..', 'Update.exe');

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "grunt build",
     "start": "ember electron",
     "test": "grunt validate",
+    "codestyle": "grunt codestyle",
     "build-native-deps-32": "electron-rebuild -a ia32 -w keytar",
     "build-native-deps-64": "electron-rebuild -a x64 -w keytar",
     "installer": "grunt installer",
@@ -27,7 +28,7 @@
     "broccoli-asset-rev": "^2.2.0",
     "codecov": "^1.0.1",
     "electron-packager": "^5.2.1",
-    "electron-prebuilt": "^0.37.2",
+    "electron-prebuilt": "^0.36.12",
     "electron-rebuild": "^1.1.3",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.4.2",
@@ -44,7 +45,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.4.0",
     "ember-disable-proxy-controllers": "^1.0.1",
-    "ember-electron": "^1.2.0",
+    "ember-electron": "^1.3.2",
     "ember-export-application-global": "^1.0.4",
     "ember-inspector": "^1.9.5",
     "ember-load-initializers": "^0.5.0",
@@ -81,13 +82,17 @@
     "overwrite": true,
     "sign": null,
     "strict-ssl": null,
+    "osx-sign": {
+      "identity": "Felix Rieseberg"  
+    },
     "version-string": {
       "CompanyName": "Ghost Foundation",
       "LegalCopyright": "Copyright (c) 2013-2016 Ghost Foundation",
       "FileDescription": "Ghost for Desktops",
       "ProductName": "Ghost",
       "InternalName": "Ghost"
-    }
+    },
+    "version": "0.36.12"
   },
   "dependencies": {
     "color-scheme": "0.0.5",

--- a/tests/fixtures/auto-update.js
+++ b/tests/fixtures/auto-update.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export const autoUpdateMock = Ember.Service.extend({
+    appVersion: '1.0.0',
+    checkForUpdates() {},
+    updateAndShutdown() {}
+ });

--- a/tests/unit/components/gh-preferences-test.js
+++ b/tests/unit/components/gh-preferences-test.js
@@ -1,19 +1,14 @@
-import {
-    moduleForComponent, test
-}
-from 'ember-qunit';
+import {moduleForComponent, test} from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import {
-    blogs
-}
-from '../../fixtures/blogs';
-
-/**
- * Test Preparation
- */
+import {blogs} from '../../fixtures/blogs';
+import {autoUpdateMock} from '../../fixtures/auto-update';
 
 moduleForComponent('gh-preferences', 'Unit | Component | gh preferences', {
-    unit: true
+    unit: true,
+    beforeEach: function () {
+        this.register('service:auto-update', autoUpdateMock);
+        this.inject.service('auto-update', { as: 'autoUpdate' });
+    }
 });
 
 /**

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,11 +1,13 @@
-import {
-    moduleFor, test
-}
-from 'ember-qunit';
+import {moduleFor, test} from 'ember-qunit';
+import {autoUpdateMock} from '../../fixtures/auto-update';
 
 moduleFor('route:application', 'Unit | Route | application', {
     // Specify the other units that are required for this test.
-    needs: ['model:blog']
+    needs: ['model:blog', 'service:window-menu'],
+    beforeEach: function () {
+        this.register('service:auto-update', autoUpdateMock);
+        this.inject.service('auto-update', { as: 'autoUpdate' });
+    }
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/services/auto-update-test.js
+++ b/tests/unit/services/auto-update-test.js
@@ -1,0 +1,356 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:auto-update', 'Unit | Service | auto update', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+test('it exists', function(assert) {
+    let service = this.subject();
+    assert.ok(service);
+});
+
+test('reports the correct environment', function(assert) {
+    let service = this.subject();
+    assert.ok(service.get('environment'));
+});
+
+test('reports the correct application version', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            getVersion() {
+                                return '1.0.0-beta';
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    assert.equal(service.get('appVersion'), '1.0.0-beta');
+
+    window.requireNode = oldRequire;
+});
+
+test('calls setup if during checkForUpdates', function(assert) {
+    let oldRequire = window.requireNode;
+    let service = this.subject();
+    
+    service.set('environment', 'production');
+    service._setup = () => assert.ok(true);
+    service.checkForUpdates();
+});
+
+test('can call checkForUpdates from the wrong environment', function(assert) {
+    assert.expect(0);
+    
+    let service = this.subject();
+    service.checkForUpdates();
+});
+
+test('can call setup from the wrong environment', function(assert) {
+    assert.expect(0);
+    
+    let service = this.subject();
+    service._setup();
+});
+
+test('calls Electron\'s autoUpdater for update checking', function(assert) {
+    let oldRequire = window.requireNode;
+    let service = this.subject();
+    
+    service.set('environment', 'production');
+    service.set('autoUpdater', {
+        checkForUpdates() {
+            assert.ok(true);
+        }
+    });
+    service.checkForUpdates();
+});
+
+test('attempts to update before shutting down if an update is downloaded', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            quit() {
+                                assert.ok(false);
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    service.set('isUpdateDownloaded', true);
+    service.set('autoUpdater', {
+        quitAndInstall() {
+            assert.ok(true);
+        }
+    });
+    service.updateAndShutdown();
+
+    window.requireNode = oldRequire;
+});
+
+test('does not attempt to update if no update is downloaded', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            quit() {
+                                assert.ok(true);
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    service.set('isUpdateDownloaded', false);
+    service.set('autoUpdater', {
+        quitAndInstall() {
+            assert.ok(false);
+        }
+    });
+    service.updateAndShutdown();
+
+    window.requireNode = oldRequire;
+});
+
+test('_setup sets the feed url', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            setFeedURL(url) {
+                                assert.ok(url);
+                            },
+                            on() {}
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    service.set('appVersion', '1.0.0-beta');
+    service.set('environment', 'production');
+    service._setup();
+
+    window.requireNode = oldRequire;
+});
+
+test('_setup handles autoUpdater events', function(assert) {
+    assert.expect(4);
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            setFeedURL() {},
+                            on(e, handler) { 
+                                if (e === 'checking-for-update') {
+                                    assert.ok(true, 'handles checking-for-update');
+                                }
+                                
+                                if (e === 'update-available') {
+                                    assert.ok(true, 'handles update-available');
+                                }
+                                
+                                if (e === 'update-downloaded') {
+                                    assert.ok(true, 'handles update-downloaded');
+                                }
+                                
+                                if (e === 'update-not-available') {
+                                    assert.ok(true, 'handles update-not-available');
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    service.set('appVersion', '1.0.0-beta');
+    service.set('environment', 'production');
+    service._setup();
+
+    window.requireNode = oldRequire;
+});
+
+test('autoUpdater\'s update checks is reflected in isCheckingForUpdate', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            setFeedURL() {},
+                            on(e, handler) { 
+                                if (e === 'checking-for-update') {
+                                    handler();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    service.set('appVersion', '1.0.0-beta');
+    service.set('environment', 'production');
+    service._setup();
+    
+    assert.equal(service.get('isCheckingForUpdate'), true);
+
+    window.requireNode = oldRequire;
+});
+
+test('autoUpdater\'s update-available is reflected in isUpdateAvailable', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            setFeedURL() {},
+                            on(e, handler) { 
+                                if (e === 'update-available') {
+                                    handler();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    service.set('appVersion', '1.0.0-beta');
+    service.set('environment', 'production');
+    service._setup();
+    
+    assert.equal(service.get('isUpdateAvailable'), true);
+
+    window.requireNode = oldRequire;
+});
+
+test('autoUpdater\'s update-downloaded is reflected in isUpdateDownloaded', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            setFeedURL() {},
+                            on(e, handler) { 
+                                if (e === 'update-downloaded') {
+                                    handler();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    service.set('appVersion', '1.0.0-beta');
+    service.set('environment', 'production');
+    service._setup();
+    
+    assert.equal(service.get('isUpdateDownloaded'), true);
+
+    window.requireNode = oldRequire;
+});
+
+test('autoUpdater\'s update-not-available is reflected in isUpdateAvailable', function(assert) {
+    let oldRequire = window.requireNode;
+
+    window.requireNode = function(target) {
+        if (target === 'electron') {
+            return {
+                remote: {
+                    require(module) {
+                        return {
+                            setFeedURL() {},
+                            on(e, handler) { 
+                                if (e === 'update-not-available') {
+                                    handler();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            return oldRequire(...arguments);
+        }
+    }
+
+    let service = this.subject();
+    service.set('appVersion', '1.0.0-beta');
+    service.set('environment', 'production');
+    service._setup();
+    
+    assert.equal(service.get('isUpdateAvailable'), false);
+
+    window.requireNode = oldRequire;
+});

--- a/tests/unit/utils/window-menu-test.js
+++ b/tests/unit/utils/window-menu-test.js
@@ -7,7 +7,7 @@ test('creates a menu (5 elements, 6 for OS X)', function(assert) {
     let result = setup();
     let expected = (process.platform === 'darwin') ? 6 : 5;
 
-    assert.equal(result.items.length, expected);
+    assert.equal(result.length, expected);
 });
 
 test('reloads a given BrowserWindow', function(assert) {


### PR DESCRIPTION
 * Adds an auto updater service (which currently works on OS X), which is able to fetch new versions of the app and update itself. The service is correctly configured, but our dev builds are not code signed - the app will therefore refuse to update to them.
 * Adds a window menu service, allowing other ember components to call the service to change the window menu. This allows us to update on Cmd+Q. It also allows us to localize the blog shortcuts (bugfix) and to have the blogs in the window menu, under view.
* Minor bugfixes and changes in the app's entry logic.