### PR TITLE
Adding preferences pane to menu bar

### DIFF
--- a/app/components/gh-switcher.js
+++ b/app/components/gh-switcher.js
@@ -18,11 +18,13 @@ export default Component.extend({
     },
 
     /**
-     * Setups the shortcut handling
+     * Setup shortcut handling for switching to blogs, and switching to
+     * the preferences pane.
      */
     _setupQuickSwitch() {
         let blogMenuItems = [{type: 'separator'}];
 
+        // The first 9 blogs are added to the 'View' menu.
         this.get('blogs')
             .slice(0, 8)
             .map((blog, i) => {
@@ -33,7 +35,10 @@ export default Component.extend({
                 });
             });
 
-        this.get('windowMenu').addBlogsToMenu(blogMenuItems);
+        this.get('windowMenu').addQuickSwitchItemsToMenu(
+            () => this.send('showPreferences'),
+            blogMenuItems
+        );
     },
 
     /**
@@ -97,7 +102,7 @@ export default Component.extend({
     /**
      * Gives a blog a random color
      *
-     * @param id - Ember Data id of the blog to remove
+     * @param id - Ember Data id of the blog to change the color of.
      */
     changeBlogColor(id) {
         if (id) {

--- a/app/styles/components/switcher.css
+++ b/app/styles/components/switcher.css
@@ -64,8 +64,7 @@
     cursor: default;
 }
 
-.switcher .add-blog-button,
-.switcher .preferences-button {
+.switcher .add-blog-button {
     margin-bottom: 5px;
     color: var(--lightgrey);
     font-size: 2.4rem;
@@ -73,8 +72,7 @@
     transition: opacity 0.3s ease;
 }
 
-.switcher .add-blog-button:hover,
-.switcher .preferences-button:hover {
+.switcher .add-blog-button:hover {
     color: #fff;
     opacity: 0.7;
     box-shadow: none;

--- a/app/templates/components/gh-switcher.hbs
+++ b/app/templates/components/gh-switcher.hbs
@@ -9,9 +9,6 @@
     {{/each}}
 </div>
 <div class="function-buttons">
-    <div {{action "showPreferences"}} class="preferences-button switch-btn">
-        <span><i class="icon-settings"></i></span>
-    </div>
     <div {{action "showAddBlog"}} class="add-blog-button switch-btn">
         <span>+</span>
     </div>

--- a/app/utils/window-menu.js
+++ b/app/utils/window-menu.js
@@ -211,12 +211,21 @@ export function setup() {
     ];
 
     if (process.platform === 'darwin') {
+        // Mac OS is a special snowflake.
         template.unshift({
             label: 'Ghost',
             submenu: [
                 {
                     label: 'About Ghost',
                     role: 'about'
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    // The click action gets injected from gh-switcher
+                    label: 'Preferences',
+                    accelerator: 'CmdOrCtrl+,'
                 },
                 {
                     type: 'separator'
@@ -254,6 +263,16 @@ export function setup() {
                     }
                 }
             ]
+        });
+    } else {
+        // Windows and Linux
+        template.unshift({
+            label: 'File',
+            submenu: [{
+                // The click action gets injected from gh-switcher.
+                label: 'Preferences',
+                accelerator: 'CmdOrCtrl+,'
+            }]
         });
     }
 

--- a/tests/integration/components/gh-switcher-test.js
+++ b/tests/integration/components/gh-switcher-test.js
@@ -74,17 +74,6 @@ test('a click on the "add blog" sign requests "add blog" ui', function(assert) {
     this.$('.add-blog-button').click();
 });
 
-test('a click on the "preferences" sign requests "preferences" ui', function(assert) {
-    this.set('_blogs', blogs);
-    this.set('_showPreferences', () => {
-        // We just ensure that the assert is called
-        assert.ok(true);
-    });
-
-    this.render(hbs`{{gh-switcher blogs=_blogs showPreferences=(action _showPreferences)}}`);
-    this.$('.preferences-button').click();
-});
-
 test('a right click on a blog opens the context menu', function(assert) {
     let oldRequire = window.requireNode;
     let mockRemote = { BrowserWindow: {}, Menu: {}, globalShortcut: {}, getCurrentWindow() { return true; } };
@@ -106,16 +95,16 @@ test('a right click on a blog opens the context menu', function(assert) {
             oldRequire(...arguments);
         }
     }
-    
+
     this.set('_blogs', [blogs[0]]);
     this.render(hbs`{{gh-switcher blogs=_blogs}}`);
-    
+
     let element = document.querySelector('.switcher-blogs .switch-btn');
     let event = document.createEvent('MouseEvents');
     let x = 10, y = 10;
-    
+
     event.initMouseEvent('contextmenu', true, true, element.ownerDocument.defaultView, 1, x, y, x, y, false, false, false, false, 2, null);
     element.dispatchEvent(event);
-    
+
     window.requireNode = oldRequire;
 });

--- a/tests/unit/components/gh-switcher-test.js
+++ b/tests/unit/components/gh-switcher-test.js
@@ -36,7 +36,7 @@ moduleForComponent('gh-switcher', 'Unit | Component | gh switcher', {
 
 test('removeBlog removes a blog', function(assert) {
     assert.expect(3);
-    
+
     const targetObject = {
         blogRemoved: function() {
             // This assertion will be called when the action is triggered
@@ -54,7 +54,7 @@ test('removeBlog removes a blog', function(assert) {
     Ember.run(() => component.removeBlog('testid'));
 });
 
-test('editBlog edits a blog', function(assert) {   
+test('editBlog edits a blog', function(assert) {
     const targetObject = {
         showEditBlog: function() {
             // This assertion will be called when the action is triggered

--- a/tests/unit/utils/window-menu-test.js
+++ b/tests/unit/utils/window-menu-test.js
@@ -3,9 +3,9 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | window menu');
 
-test('creates a menu (5 elements, 6 for OS X)', function(assert) {
+test('creates a menu (6 elements)', function(assert) {
     let result = setup();
-    let expected = (process.platform === 'darwin') ? 6 : 5;
+    let expected = 6;
 
     assert.equal(result.length, expected);
 });


### PR DESCRIPTION
Removes the preferences button from the switcher, adds it to Ghost Desktop's Application menu (Apple), and to the File menu (Windows, Linux). Fixes #96 