### PR TITLE
Ensure links open externally

### DIFF
--- a/main/preload.js
+++ b/main/preload.js
@@ -153,9 +153,33 @@ function setupSpellChecker() {
 }
 
 /**
+ * This method ensures that all links are set to "external"
+ * If a user adds a link in markedown that doesn't have the
+ * correct "target", the app *will* open it in the current
+ * webview, which is obviously bad.
+ * 
+ * This works together with a CSS animation, which is defined
+ * in /public/assets/inject/css/all.css
+ */
+function setupLinkExternalizer() {
+    function externalize(event) {
+        if (event.animationName === 'linkInserted') {
+            let t = event.target;
+
+            if (t.href && t.href.indexOf(location.hostname) === -1) {
+                t.setAttribute('target', '_blank');
+            }
+        }
+    }
+
+    document.addEventListener('webkitAnimationStart', externalize, false);
+}
+
+/**
  * Init
  */
 setTimeout(checkStatus, 100);
 window.addEventListener('mousedown', resetSelection);
 window.addEventListener('contextmenu', handleContextMenu);
 setupSpellChecker();
+setupLinkExternalizer();

--- a/public/assets/inject/css/all.css
+++ b/public/assets/inject/css/all.css
@@ -6,3 +6,14 @@
 .gh-nav-menu-icon {
     display: none;
 }
+
+a {
+    animation-duration: 0.001s;
+    animation-name: linkInserted;
+}
+
+/* Little hack that allows us to detect inserted links */
+@keyframes linkInserted {  
+	from { opacity: 0.99; }
+	to { opacity: 1; }  
+}


### PR DESCRIPTION
We're using a little CSS hack to get an event as soon as a link is added - once done, we ensure that it is opened externally, if it is indeed an external link.

Closes #131 

