### PR TITLE
Fixing build issue on Node 6

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,9 +1,9 @@
 /*jshint node:true*/
 /* global require, module */
 const EmberApp = require('ember-cli/lib/broccoli/ember-app'),
-    mythCompress = isProduction || environment === 'test',
     environment = EmberApp.env(),
-    isProduction = environment === 'production';
+    isProduction = environment === 'production',
+    mythCompress = isProduction || environment === 'test';
 
 module.exports = function(defaults) {
     const isTest = (process.env.EMBER_ENV || 'development') === 'test';


### PR DESCRIPTION
Fixing an odd Node 6 issue in which ember cli complains about isProduction not being defined. I suspect this may have something to do with variable declaration order.

