### PR TITLE
Remove -w keytar so spellchecker is included

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "start": "grunt shell:fetchContributors && ember electron",
     "test": "grunt validate",
     "codestyle": "grunt codestyle",
-    "build-native-deps-32": "electron-rebuild -a ia32 -w keytar",
-    "build-native-deps-64": "electron-rebuild -a x64 -w keytar",
+    "build-native-deps-32": "electron-rebuild -a ia32",
+    "build-native-deps-64": "electron-rebuild -a x64",
     "build-native-deps": "electron-rebuild",
     "installer": "grunt installer",
     "dmg": "grunt dmg"


### PR DESCRIPTION
Both `keytar` and `spellchecker` require native builds, so remove the explicit `-w keytar` parameter to allow any module to be built.

Closes #154 