### PR TITLE
Changing the upgrade notification text

### DIFF
--- a/main/preload.js
+++ b/main/preload.js
@@ -1,6 +1,7 @@
 // Preload various modules before actual loading
 // the individual Ghost blogs
 require('./preload/check-login');
+require('./preload/upgrade-notification');
 require('./preload/dragdrop');
 require('./preload/spellchecker');
 require('./preload/external-links');

--- a/main/preload/upgrade-notification.js
+++ b/main/preload/upgrade-notification.js
@@ -1,0 +1,32 @@
+'use strict';
+
+let attempts = 100;
+const betterUpgradeMessage =  'A new version of Ghost Core is available! Hot Damn. \
+<a href="http://support.ghost.org/how-to-upgrade/" target="_blank">Click here</a> \
+to learn more on upgrading Ghost Core.';
+
+/**
+ * Simple timeout + attempt based function that checks to see if Ghost Core has an update available,
+ * and replaces the notification text with something a little more specific.';
+ */
+function upgradeNotification() {
+    if (attempts === 0) {
+        return;
+    }
+
+    let ghostCoreUpgradeAvailable = document.querySelector('aside.gh-alerts .gh-alert-content');
+
+    if (ghostCoreUpgradeAvailable) {
+        // The notification was found, replace the text.
+        ghostCoreUpgradeAvailable.innerHTML = betterUpgradeMessage;
+    } else {
+        // Decrement the attempt count, and check again.
+        attempts -= 1;
+        setTimeout(upgradeNotification, 50);
+    }
+}
+
+/**
+ * Init
+ */
+setTimeout(upgradeNotification, 50);


### PR DESCRIPTION
Changing the ghost core upgrade notification text to be a lil bit more clear about what it is you need to upgrade. Fixes(?) #167 

@felixrieseberg, @ErisDS let me know if either of you think there's a better way to message this 😅 