### PR TITLE
Slightly improve paste performance

### DIFF
--- a/main/preload/spellchecker.js
+++ b/main/preload/spellchecker.js
@@ -124,9 +124,26 @@ function setupSpellChecker(data) {
     resetSelection();
 }
 
+/**
+ * Handles pasting, temporarily disabling spellcheck to speed things up
+ * @param {PasteEvent} e
+ */
+function handlePaste(e) {
+    if (e.target && e.target.id && e.target.spellcheck) {
+        const elem = document.getElementById(e.target.id);
+        elem.setAttribute('spellcheck', false);
+
+        window.requestIdleCallback(function () {
+            elem.setAttribute('spellcheck', true);
+        })
+    }
+}
+
 function setup() {
     window.addEventListener('mousedown', resetSelection);
     window.addEventListener('contextmenu', handleContextMenu);
+	window.addEventListener('paste', handlePaste);
+
     ipc.on('spellchecker', (sender, data) => setupSpellChecker(data));
 }
 


### PR DESCRIPTION
We can’t really fix how the spellchecker works, but we can fix *when*
it works. This is a poor man’s solution to our original problem (pastes
taking too much time) - whenever text is pasted into the textarea, we
briefly disable the spellchecker, just to re-enable it a few moments
later.

Closes #168