### PR TITLE
:memo: add link back to main Ghost repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The project is maintained by a non-profit organisation called the **Ghost Foundation**, along with an amazing group of independent [contributors](https://github.com/TryGhost/Ghost-Desktop/contributors). We're trying to make publishing software that changes the shape of online journalism.
 
-# Ghost Desktop
+# Ghost Desktop - Manage your [Ghost](https://github.com/TryGhost/Ghost) blogs natively
 Ghost Desktop is a beautiful desktop application that allows you to easily manage multiple Ghost blogs and work without distractions. If you're interested in giving us a hand, [check out the contributing guide](https://github.com/TryGhost/Ghost-Desktop/tree/master/docs)!
 
 # Copyright & License


### PR DESCRIPTION
- makes it more obvious that Ghost Desktop is only intended to work with Ghost :smile: