### PR TITLE
Switch to new native system font stack

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,7 +11,6 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/ghost-desktop.css">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,700">
 
     {{content-for "head-footer"}}
   </head>

--- a/app/styles/layouts/loading.css
+++ b/app/styles/layouts/loading.css
@@ -1,7 +1,7 @@
 /* Loading state */
 .gh-loading-side {
     position: relative;
-    flex: 0 0 235px;
+    flex: 0 0 205px;
     display: flex;
     flex-direction: column;
     min-width: 0;

--- a/app/styles/patterns/global.css
+++ b/app/styles/patterns/global.css
@@ -16,7 +16,7 @@
     --green: #9fbb58;
     /* Style values */
     --border-radius: 4px;
-    --font-family: "Open Sans", sans-serif;
+    --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
     --font-family-mono: Consolas, "Liberation Mono", Menlo, Courier, monospace;
 }
 
@@ -65,7 +65,7 @@ html {
     width: 100%;
     /* Prevent elastic scrolling on the whole page */
     height: 100%;
-    font: 62.5%/1.65 "Open Sans", sans-serif;
+    font: 62.5%/1.65 var(--font-family);
 
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }

--- a/main/load-error/error.html
+++ b/main/load-error/error.html
@@ -7,14 +7,13 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            font-family: "Open Sans", sans-serif;
+            font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Open Sans","Helvetica Neue",sans-serif;
         }
-        
+
         .error {
             text-align: center;
         }
     </style>
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,700">
 </head>
 
 <body>
@@ -26,12 +25,12 @@
     <script>
         var query = location.search.substr(1);
         var result = {};
-        
+
         query.split("&").forEach((part) => {
             var item = part.split("=");
             result[item[0]] = decodeURIComponent(item[1]);
         });
-        
+
         if (result && result.error) {
             var errorElement = document.getElementById('details');
             errorElement.textContent = result.error;


### PR DESCRIPTION
Based on an increasingly popular trend and modern web typography capabilities, switch out Google Fonts for default native system fonts, tailored in a stack to suit every device. Also makes some very minor visual adjustments to suit.

Nixes all references to Google Fonts, and provides a faster rendering experience and fewer http requests. 💃 

Reference material:
- https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/
- https://medium.design/system-shock-6b1dc6d6596f#.rhqx5fmyz

Dependencies:
- https://github.com/TryGhost/Ghost-Admin/pull/211
- https://github.com/TryGhost/Ghost/pull/7219
- https://github.com/TryGhost/Ghost-Desktop/pull/190