### PR TITLE
Handle changed password gracefully

### DIFF
--- a/app/components/gh-app.js
+++ b/app/components/gh-app.js
@@ -214,8 +214,9 @@ export default Component.extend({
          *
          * @param blog - Blog to edit
          */
-        showEditBlog(blog) {
+        showEditBlog(blog, editWarning) {
             this.set('blogToEdit', blog);
+            this.set('editWarning', editWarning);
             this.showEditBlogUI();
         },
 

--- a/app/components/gh-edit-blog.js
+++ b/app/components/gh-edit-blog.js
@@ -9,8 +9,9 @@ const {Component} = Ember;
 export default Component.extend({
     store: Ember.inject.service(),
     classNames: ['gh-edit-blog'],
-    classNameBindings: ['isBasicAuth:basic-auth'],
+    classNameBindings: ['isBasicAuth:basic-auth', 'hasWarning'],
     isBasicAuth: false,
+    hasWarning: Ember.computed.bool('editWarning'),
 
     /**
      * A boolean value that is true if any errors are present
@@ -116,6 +117,10 @@ export default Component.extend({
             if (!record) {
                 // If the blog doesn't already exist, create it
                 record = this.get('store').createRecord('blog', {url});
+            } else {
+                // If it does exist, ensure that everybody knows this is super new
+                // This ensures we update even if only the password field was updated
+                record.set('isResetRequested', true);
             }
 
             record.setProperties({

--- a/app/models/blog.js
+++ b/app/models/blog.js
@@ -17,6 +17,7 @@ export default DS.Model.extend({
     }),
     basicUsername: attr('string'),
     basicPassword: attr('string'),
+    isResetRequested: attr('boolean'),
 
     /**
      * Convenience method, marking the blog as selected (and saving)

--- a/app/styles/components/edit-blog.css
+++ b/app/styles/components/edit-blog.css
@@ -19,6 +19,10 @@
     align-self: center;
 }
 
+.gh-edit-blog.has-warning {
+    height: 420px;
+}
+
 .gh-edit-blog .form-group {
     margin-bottom: 1.5rem;
 }
@@ -42,4 +46,9 @@
 
 .basic-auth-username {
     margin-top: 10px;
+}
+
+.gh-edit-blog .warning {
+    font-size: 0.8em;
+    color: #e25440;
 }

--- a/app/templates/components/gh-app.hbs
+++ b/app/templates/components/gh-app.hbs
@@ -17,14 +17,18 @@
     {{gh-find-in-webview isActive=isFindInViewActive}}
 
     {{#if isEditBlogVisible}}
-        {{gh-edit-blog blogAdded="blogAdded" blog=blogToEdit}}
+        {{gh-edit-blog
+            blogAdded="blogAdded"
+            blog=blogToEdit
+            editWarning=editWarning
+        }}
     {{else if isPreferencesVisible}}
         {{gh-preferences}}
     {{/if}}
 
     {{#if blogs}}
         {{#each blogs as |blog|}}
-            {{gh-instance-host blog=blog}}
+            {{gh-instance-host blog=blog showEditBlog="showEditBlog"}}
         {{/each}}
     {{/if}}
 </div>

--- a/app/templates/components/gh-edit-blog.hbs
+++ b/app/templates/components/gh-edit-blog.hbs
@@ -3,6 +3,9 @@
         <section class="gh-flow-content fade-in">
             {{#if blog}}
                 <p>{{blog.name}}</p>
+                {{#if editWarning}}
+                    <p class="warning">{{editWarning}}</p>
+                {{/if}}
             {{else}}
                 <p>Welcome! Before we get started, please tell us where to find your blog:</p>
             {{/if}}

--- a/main/preload/check-login.js
+++ b/main/preload/check-login.js
@@ -22,6 +22,25 @@ function checkStatus() {
 }
 
 /**
+ * We defer to the actual click on the login button
+ * before we check whether or not the login actually
+ * succeeded
+ */
+function init() {
+    const element = document.querySelector('button.login');
+
+    if (element) {
+        element.off('click');
+        element.on('click', () => {
+            console.log('login-check-again');
+            setTimeout(checkStatus, 100);
+        });
+    } else {
+        setTimeout(init, 100);
+    }
+}
+
+/**
  * Init
  */
-setTimeout(checkStatus, 100);
+setTimeout(init, 100);


### PR DESCRIPTION
Previously, when the password was incorrect, we didn't really handle things all that well - we displayed the individual blog's login page, but did not actually capture a newly entered password. Now, we detect the login error, display the 'edit blog' modal and retry as soon as the user has hit 'save' again.