### PR TITLE
Electron 1.4

### DIFF
--- a/app/styles/components/instance-host.css
+++ b/app/styles/components/instance-host.css
@@ -1,15 +1,12 @@
 .instance-host {
-    flex-grow: 1;
-    width: 100%;
-    height: 100%;
     position: relative;
-    display: none;
-    visibility: collapse;
+    width: 0px;
+    height: 0px;
 }
 
 #ember-testing .instance-host {
-    display: block;
-    visibility: visible;
+    width: 500px;
+    height: 500px;
 }
 
 .instance-host webview {
@@ -17,8 +14,10 @@
 }
 
 .instance-host.selected {
-    display: block;
-    visibility: visible;
+    flex-grow: 1;
+    display: inline-flex;
+    width: 100%;
+    height: 100%;
 }
 
 .instance-host webview.host {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "codecov": "^1.0.1",
     "cross-env": "^3.1.3",
     "devtron": "^1.4.0",
-    "electron": "1.3.8",
+    "electron": "1.4.4",
     "electron-packager": "^8.1.0",
     "electron-rebuild": "^1.3.0",
     "ember-ajax": "^2.5.0",
@@ -105,11 +105,11 @@
       "ProductName": "Ghost",
       "InternalName": "Ghost"
     },
-    "version": "1.3.5"
+    "version": "1.4.4"
   },
   "dependencies": {
-    "electron-window-state": "^3.0.3",
-    "he": "^0.5.0",
+    "electron-window-state": "^3.1.0",
+    "he": "^1.1.0",
     "hexrgb": "0.0.2",
     "is-reachable": "^1.3.0",
     "keytar": "^3.0.0",


### PR DESCRIPTION
We previously didn't upgrade to Electron 1.4 right away, because we had some trouble with webviews unloading in unpredictable ways - this is now fixed, so we can enjoy the 1.4-goodness.