### PR TITLE
Mac App Store Builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,6 @@
 //
 // **Debug tip:** If you have any problems with any Grunt tasks, try running them with the `--verbose` command
 
-const package = require('./package.json');
 const winTools = require('./scripts/create-windows-build');
 
 const configureGrunt = function (grunt) {
@@ -21,68 +20,6 @@ const configureGrunt = function (grunt) {
     }
 
     const config = {
-
-        jscs: {
-            app: {
-                files: {
-                    src: [
-                        'app/**/*.js',
-                        '!node_modules/**/*.js',
-                        '!bower_components/**/*.js',
-                        '!tests/**/*.js',
-                        '!tmp/**/*.js',
-                        '!dist/**/*.js'
-                    ]
-                }
-            },
-
-            tests: {
-                files: {
-                    src: [
-                        'tests/**/*.js'
-                    ]
-                }
-            }
-        },
-
-        shell: {
-            build: {
-                command: `ember electron:package --environment production --arch x64 --platform ${process.platform} --app-version ${package.version} --overwrite`
-            },
-            build32: {
-                command: `ember electron:package --environment production --arch ia32 --platform ${process.platform} --app-version ${package.version} --overwrite`
-            },
-            mas: {
-                command: `ember electron:package --environment production --arch x64 --platform mas --app-version ${package.version} --overwrite --app-bundle-id com.ghostfoundation.ghost`
-            },
-            logCoverage: {
-                command: 'node ./scripts/log-coverage.js'
-            },
-            dmg: {
-                command: 'node ./scripts/create-osx-build.js'
-            },
-            fetchContributors: {
-                command: 'node ./scripts/fetch-contributors.js'
-            }
-        },
-
-        clean: {
-            builds32: [
-                'electron-builds/Ghost-win32-ia32-installer/**/*',
-                'electron-builds/Ghost-win32-ia32/**/*',
-                'electron-builds/Ghost-linux-ia32-installer/**/*',
-                'electron-builds/Ghost-linux-ia32/**/*',
-                'electron-builds/Ghost-darwin-ia32/**/*'
-                ],
-            builds64: [
-                'electron-builds/Ghost-win32-x64-installer/**/*',
-                'electron-builds/Ghost-win32-x64/**/*',
-                'electron-builds/Ghost-linux-x64-installer/**/*',
-                'electron-builds/Ghost-linux-x64/**/*',
-                'electron-builds/Ghost-darwin-x64/**/*'
-                ],
-        },
-
         'create-windows-installer': {
             ia32: {
                 appDirectory: './electron-builds/Ghost-win32-ia32',
@@ -137,18 +74,9 @@ const configureGrunt = function (grunt) {
                 }
             }
         }
-
     };
 
     grunt.initConfig(config);
-
-    grunt.registerTask('build', 'Compile Ghost Desktop for the current platform', ['shell:fetchContributors', 'shell:build']);
-    grunt.registerTask('installer-32', ['clean:builds32', 'shell:fetchContributors', 'shell:build32', 'create-windows-installer:ia32'])
-    grunt.registerTask('installer-64', ['clean:builds64', 'shell:fetchContributors', 'shell:build', 'create-windows-installer:x64'])
-    grunt.registerTask('installer', 'Create Windows Installers for Ghost', ['installer-32', 'installer-64']);
-    grunt.registerTask('mas', ['clean:builds64', 'shell:fetchContributors', 'shell:mas']);
-    grunt.registerTask('debian', ['clean:builds64', 'shell:fetchContributors', 'shell:build', 'electron-installer-debian']);
-    grunt.registerTask('dmg', 'Create an OS X dmg for Ghost', ['shell:fetchContributors', 'shell:build', 'shell:dmg']);
 };
 
 module.exports = configureGrunt;

--- a/assets/mas/app-contents-info.plist
+++ b/assets/mas/app-contents-info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Ghost</string>
+	<key>CFBundleExecutable</key>
+	<string>Ghost</string>
+	<key>CFBundleIconFile</key>
+	<string>electron.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.ghostfoundation.ghost</string>
+	<key>ElectronTeamID</key>
+	<string>6RKE5ET24A</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Ghost</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${CFBundleShortVersionString}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CFBundleVersion}</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.8.0</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSAppleScriptEnabled</key>
+	<string>YES</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>AtomApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (c) 2016 Ghost Foundation</string>
+	<true/>
+</dict>
+</plist>

--- a/assets/mas/app-store-child.plist
+++ b/assets/mas/app-store-child.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+  </dict>
+</plist>

--- a/assets/mas/app-store-parent.plist
+++ b/assets/mas/app-store-parent.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<string>6RKE5ET24A.com.ghostfoundation.ghost</string>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.print</key>
+	<true/>
+</dict>
+</plist>

--- a/assets/mas/app-store-parent.plist
+++ b/assets/mas/app-store-parent.plist
@@ -12,7 +12,5 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>com.apple.security.print</key>
-	<true/>
 </dict>
 </plist>

--- a/assets/mas/helper-contents-info.plist
+++ b/assets/mas/helper-contents-info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Ghost Helper</string>
+	<key>CFBundleExecutable</key>
+	<string>Ghost Helper</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.ghostfoundation.ghost.helper</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Ghost Helper</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${CFBundleShortVersionString}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CFBundleVersion}</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.8.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ghost-desktop",
   "version": "0.7.0",
+  "build": "0700",
   "description": "Desktop Client for Ghost",
   "private": true,
   "directories": {
@@ -9,7 +10,14 @@
   },
   "homepage": "https://github.com/tryghost/ghost-desktop",
   "scripts": {
-    "build": "grunt build",
+    "build": "ember electron:package --environment production --app-version $npm_package_version --overwrite",
+    "build:win": "npm run clean:builds32 && npm run build -- --platform win32 --arch ia32",
+    "build:macos": "npm run build -- --platform darwin --arch x64",
+    "build:mas": "npm run build -- --platform mas --app-bundle-id com.ghostfoundation.ghost",
+    "build:contrib": "node ./scripts/fetch-contributors.js",
+    "clean:builds": "rimraf ./electron-builds",
+    "clean:builds64": "rimraf ./electron-builds/Ghost*x64*/",
+    "clean:builds32": "rimraf ./electron-builds/Ghost*ia32*/",
     "start": "node ./scripts/fetch-contributors.js && ember electron",
     "test": "npm run test:lint && npm run test:unit",
     "test:unit": "ember electron:test",
@@ -19,10 +27,11 @@
     "rebuild:32": "electron-rebuild -a ia32",
     "rebuild:64": "electron-rebuild -a x64",
     "installer": "grunt installer",
-    "installer:32": "grunt installer-32",
-    "installer:64": "grunt installer-32",
-    "installer:debian": "grunt debian",
-    "installer:dmg": "grunt dmg"
+    "installer:32": "npm run clean:builds32 && npm run build:contrib && grunt create-windows-installer:ia32",
+    "installer:64": "npm run clean:builds64 && npm run build:contrib && grunt create-windows-installer:x64",
+    "installer:debian": "npm run clean:builds64 && npm run build:contrib && npm run build && grunt electron-installer-debian",
+    "installer:dmg": "npm run build:contrib && npm run build && node ./scripts/create-osx-build.js",
+    "installer:mas": "npm run clean:builds64 && npm run build:contrib && npm run build:mas && node ./scripts/create-mas-build.js"
   },
   "repository": "",
   "engines": {
@@ -40,6 +49,7 @@
     "cross-env": "^3.1.3",
     "devtron": "^1.4.0",
     "electron": "1.4.4",
+    "electron-osx-sign": "^0.3.2",
     "electron-packager": "^8.1.0",
     "electron-rebuild": "^1.3.0",
     "ember-ajax": "^2.5.0",
@@ -72,17 +82,17 @@
     "eslint": "^3.5.0",
     "estraverse-fb": "^1.3.1",
     "find-parent-dir": "^0.3.0",
+    "fs-extra": "^0.30.0",
     "grunt": "^1.0.0",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
     "grunt-electron-installer": "^2.1.0",
-    "grunt-jscs": "^3.0.0",
-    "grunt-shell": "^1.3.1",
     "grunt-trimtrailingspaces": "^2.3.0",
     "lazy-require": "^2.2.0",
     "loader.js": "^4.0.11",
     "matchdep": "^1.0.1",
-    "node-fetch": "^1.6.0"
+    "node-fetch": "^1.6.0",
+    "replace-in-file": "^2.0.1",
+    "rimraf": "latest",
+    "tmp": "0.0.29"
   },
   "main": "main/entry.js",
   "ember-electron": {
@@ -97,6 +107,13 @@
     "helper-bundle-id": null,
     "icon": "assets/icons/ghost",
     "overwrite": true,
+    "ignore": [
+      "\\*.(cc|h|lib|pdb|obj|map|md|tlog|o)$",
+      "/node_modules/.*/hunspell/src",
+      "/node_modules/.*/(gyp-mac-tool|cibuild)$",
+      "/node_modules/.*/bin/cmd.js$",
+      "/node_modules/.*/tools/1to2.js$"
+    ],
     "sign": null,
     "strict-ssl": null,
     "win32metadata": {

--- a/scripts/create-mas-build.js
+++ b/scripts/create-mas-build.js
@@ -1,0 +1,62 @@
+const tmp = require('tmp');
+const path = require('path');
+const sign = require('electron-osx-sign');
+const fs = require('fs-extra');
+const replace = require('replace-in-file')
+const package = require('../package.json');
+
+function main() {
+  tmp.setGracefulCleanup();
+
+  replacePlists();
+  signAppBundle().then(() => console.log('All done!'))
+}
+
+function signAppBundle() {
+  const app = path.join(__dirname, '..', 'electron-builds/Ghost-mas-x64/Ghost.app');
+  const nm = path.join(app, 'Contents/Resources/app/node_modules');
+  const binaries = [
+    path.join(nm, 'keytar/Build/Release/keytar.node'),
+    path.join(nm, 'spellchecker/Build/Release/hunspell.a'),
+    path.join(nm, 'spellchecker/Build/Release/spellchecker.node')
+  ];
+  const entitlements = path.join(__dirname, '..', 'assets/mas/app-store-parent.plist');
+  const entitlementsInherit = path.join(__dirname, '..', 'assets/mas/app-store-child.plist');
+  const platform = 'mas';
+
+  return new Promise((resolve, reject) => {
+    sign({
+      app,
+      binaries,
+      platform,
+      entitlements,
+      'entitlements-inherit': entitlementsInherit
+    }, (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+}
+
+function replacePlists() {
+  const tmpFolder = tmp.dirSync().name;
+  const appFolder = path.join(__dirname, '..', 'electron-builds/Ghost-x64-mas/Ghost.app');
+  const assetFolder = path.join(__dirname, '..', 'assets/mas')
+  const appPlist = {
+    from: path.join(tmpFolder, 'app-contents-info.plist'),
+    to: path.join(appFolder, '/Contents/Info.plist')
+  };
+  const helperPlist = {
+    from: path.join(tmpFolder, 'helper-contents-info.plist'),
+    to: path.join(appFolder, '/Contents/Frameworks/Ghost Helper.app/Contents/Info.plist')
+  };
+  const files = `${tmpFolder}/**/*`;
+
+  fs.copySync(assetFolder, tmpFolder);
+  replace.sync({files, replace: '${CFBundleVersion}', with: package.version});
+  replace.sync({files, replace: '${CFBundleShortVersionString}', with: package.build});
+  fs.copySync(helperPlist.from, helperPlist.to);
+  fs.copySync(appPlist.from, appPlist.to);
+}
+
+main();


### PR DESCRIPTION
This PR enables us to make Mac App Store builds :package:. It also moves many Grunt tasks into npm.