### PR TITLE
Make window “vibrant” (Yosemite and up only)

### DIFF
--- a/app/components/gh-app.js
+++ b/app/components/gh-app.js
@@ -9,7 +9,7 @@ const {Component} = Ember;
 export default Component.extend({
     store: Ember.inject.service(),
     autoUpdate: Ember.inject.service(),
-    classNames: ['gh-app'],
+    classNameBindings: ['isMac:mac', ':gh-app'],
     isFindInViewActive: false,
     isMac: !!(process.platform === 'darwin'),
 

--- a/app/components/gh-switcher.js
+++ b/app/components/gh-switcher.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import {getIsYosemiteOrHigher} from '../utils/versions';
 
 const {Component} = Ember;
 
@@ -10,9 +11,10 @@ export default Component.extend({
     store: Ember.inject.service(),
     preferences: Ember.inject.service(),
     windowMenu: Ember.inject.service(),
-    classNameBindings: ['isMinimized', 'isMac:mac', ':switcher'],
+    classNameBindings: ['isMinimized', 'isMac:mac', 'isVibrant', ':switcher'],
     isMinimized: Ember.computed.alias('preferences.isQuickSwitcherMinimized'),
     isMac: !!(process.platform === 'darwin'),
+    isVibrant: getIsYosemiteOrHigher(),
 
     didRender() {
         this._super(...arguments);

--- a/app/styles/components/app.css
+++ b/app/styles/components/app.css
@@ -11,4 +11,9 @@
     justify-content: center;
     height: calc(100% - 20px);
     width: 100%;
+    background-color: rgba(255, 255, 255, .15);
+}
+
+.mac .center-host {
+    height: 100%;
 }

--- a/app/styles/components/edit-blog.css
+++ b/app/styles/components/edit-blog.css
@@ -2,10 +2,6 @@
 /* ---------------------------------------------------------- */
 
 .gh-edit-blog {
-    text-align: center;
-}
-
-.gh-edit-blog {
     position: relative;
     padding: 40px;
     max-width: 500px;
@@ -16,6 +12,7 @@
     text-align: left;
     height: 380px;
     align-self: center;
+    text-align: center;
 }
 
 .gh-edit-blog.has-warning {

--- a/app/styles/components/find-webview.css
+++ b/app/styles/components/find-webview.css
@@ -6,11 +6,11 @@
     justify-content: flex-end;
     padding-right: 20px;
     align-items: center;
-    border-bottom: #dfe1e3 1px solid;
     transition: height .25s linear;
 }
 
 .find-webview.active {
     height: 40px;
     opacity: 1;
+    border-bottom: #dfe1e3 1px solid;
 }

--- a/app/styles/components/instance-host.css
+++ b/app/styles/components/instance-host.css
@@ -2,6 +2,7 @@
     position: relative;
     width: 0px;
     height: 0px;
+    background-color: white;
 }
 
 #ember-testing .instance-host {

--- a/app/styles/components/preferences.css
+++ b/app/styles/components/preferences.css
@@ -7,6 +7,7 @@
     flex-direction: column;
     overflow: scroll;
     -webkit-user-select: none;
+    background-color: white;
 }
 
 .gh-preferences header {

--- a/app/styles/components/switcher.css
+++ b/app/styles/components/switcher.css
@@ -14,6 +14,10 @@
     transition: all linear .25s;
 }
 
+.switcher.is-vibrant {
+    background-color: inherit;
+}
+
 .switcher.mac {
     padding-top: 25px;
 }

--- a/app/utils/versions.js
+++ b/app/utils/versions.js
@@ -1,0 +1,17 @@
+/**
+ * Checks if the running system is macOS Yosemite or higher?
+ *
+ * @returns {boolean} Is the running system macOS Yosemite or higher?
+ */
+export function getIsYosemiteOrHigher() {
+    const isDarwin = requireNode('os').platform() === 'darwin';
+    const release = requireNode('os').release();
+
+    if (isDarwin && release && release.length >= 6) {
+        const major = release.slice(0, 2);
+
+        return parseInt(major) >= 14;
+    } else {
+        return false;
+    }
+}

--- a/main/entry.js
+++ b/main/entry.js
@@ -27,7 +27,7 @@ app.on('ready', function onReady() {
         stateKeeper = windowState.stateKeeper;
 
         mainWindow = new BrowserWindow(
-            Object.assign(usableState, {show: false, titleBarStyle: titleBarStyle})
+            Object.assign(usableState, {show: false, titleBarStyle, vibrancy: 'dark'})
         );
     } catch (error) {
         // Window state keeper failed, let's still open a window
@@ -36,7 +36,8 @@ app.on('ready', function onReady() {
             show: false,
             height: 800,
             width: 1000,
-            titleBarStyle: titleBarStyle
+            titleBarStyle,
+            vibrancy: 'dark'
         });
     }
 

--- a/tests/unit/utils/versions-test.js
+++ b/tests/unit/utils/versions-test.js
@@ -1,0 +1,89 @@
+import {getIsYosemiteOrHigher} from 'ghost-desktop/utils/versions';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | versions');
+
+test('getIsYosemiteOrHigher: True for Sierra', function(assert) {
+    const oldRequire = window.requireNode;
+    window.requireNode = function (module) {
+        if (module === 'os') {
+            return {
+                platform: () => 'darwin',
+                release: () => '16.1.0'
+            };
+        } else {
+            oldRequire(...arguments);
+        }
+    }
+
+    assert.ok(getIsYosemiteOrHigher());
+    window.requireNode = oldRequire;
+});
+
+test('getIsYosemiteOrHigher: True for El Capitan', function(assert) {
+    const oldRequire = window.requireNode;
+    window.requireNode = function (module) {
+        if (module === 'os') {
+            return {
+                platform: () => 'darwin',
+                release: () => '15.6.0'
+            };
+        } else {
+            oldRequire(...arguments);
+        }
+    }
+
+    assert.ok(getIsYosemiteOrHigher());
+    window.requireNode = oldRequire;
+});
+
+test('getIsYosemiteOrHigher: True for Yosemite', function(assert) {
+    const oldRequire = window.requireNode;
+    window.requireNode = function (module) {
+        if (module === 'os') {
+            return {
+                platform: () => 'darwin',
+                release: () => '14.0.0'
+            };
+        } else {
+            oldRequire(...arguments);
+        }
+    }
+
+    assert.ok(getIsYosemiteOrHigher());
+    window.requireNode = oldRequire;
+});
+
+test('getIsYosemiteOrHigher: False for Mavericks', function(assert) {
+    const oldRequire = window.requireNode;
+    window.requireNode = function (module) {
+        if (module === 'os') {
+            return {
+                platform: () => 'darwin',
+                release: () => '13.0.0'
+            };
+        } else {
+            oldRequire(...arguments);
+        }
+    }
+
+    assert.equal(getIsYosemiteOrHigher(), false);
+    window.requireNode = oldRequire;
+});
+
+test('getIsYosemiteOrHigher: False for Windows', function(assert) {
+    const oldRequire = window.requireNode;
+    window.requireNode = function (module) {
+        if (module === 'os') {
+            return {
+                platform: () => 'win32',
+                release: () => '14.0.0'
+            };
+        } else {
+            oldRequire(...arguments);
+        }
+    }
+
+    assert.equal(getIsYosemiteOrHigher(), false);
+    window.requireNode = oldRequire;
+});


### PR DESCRIPTION
Look at this hot beauty. Electron 1.4.7 (separate PR is open) introduced the ability to mark `BrowserWindows` as `vibrant`, using the native macOS `NSVisualEffectView` vibrancy available from Yosemite onwards. It's quite pretty :art:

<img width="1251" alt="screen shot 2016-11-21 at 5 34 57 pm" src="https://cloud.githubusercontent.com/assets/1426799/20512267/2de8aa28-b033-11e6-9857-475be2fb992c.png">

