### PR TITLE
Shortcuts can now wait for webview

### DIFF
--- a/app/components/gh-app.js
+++ b/app/components/gh-app.js
@@ -58,7 +58,7 @@ export default Component.extend({
     },
 
     handleCreateDraftEvent({title, content} = {title: '', content: ''}) {
-        this.get('webviewShortcuts').openNewPost({title, content});
+        this.get('webviewShortcuts').openNewPost(true, {title, content});
     },
 
     /**


### PR DESCRIPTION
Previously, the webview-shortcuts would just attempt to fire. If the webview wasn't ready, nothing would happen.

This PR updates the API, enabling the shortcuts to wait for the webview to load. 

Ref #227 
