### PR TITLE
Prefill user field from `open-blog`

### DIFF
--- a/app/components/gh-app.js
+++ b/app/components/gh-app.js
@@ -36,24 +36,26 @@ export default Component.extend({
         const ipc = this.get('ipc');
 
         ipc.notifyReady();
-        ipc.on('open-blog', (blogUrl) => this.handleOpenBlogEvent(blogUrl));
+        ipc.on('open-blog', (details) => this.handleOpenBlogEvent(details));
         ipc.on('create-draft', (details) => this.handleCreateDraftEvent(details));
     },
 
     /**
      * Open a blog. If it doesn't exist yet, open the "add blog" UI.
      *
-     * @param {String} url
+     * @param {Object} details
+     * @property {string} user - Email address of the user (for prefill)
+     * @property {string} url - Url of the blog
      */
-    handleOpenBlogEvent(rawUrl) {
-        const url = sanitizeUrl(rawUrl);
+    handleOpenBlogEvent({url, user} = {url: '', user: ''}) {
+        const sanitizedUrl = sanitizeUrl(url);
         const blogs = this.get('blogs');
-        const matchedBlog = blogs ? blogs.find((b) => b.get('url') === url) : null;
+        const matchedBlog = blogs ? blogs.find((b) => b.get('url') === sanitizedUrl) : null;
 
         if (matchedBlog) {
             this.send('switchToBlog', matchedBlog);
         } else {
-            this.send('showAddBlog', { url });
+            this.send('showAddBlog', { url: sanitizedUrl, user });
         }
     },
 

--- a/app/services/window-menu.js
+++ b/app/services/window-menu.js
@@ -181,13 +181,13 @@ export default Ember.Service.extend({
                     });
                     item.submenu.insertAt(2, {
                         label: 'Content',
-                        accelerator: 'CmdOrCtrl+Alt+L',
+                        accelerator: 'CmdOrCtrl+Alt+C',
                         name: 'open-content',
                         click: () => shortcuts.openContent()
                     });
                     item.submenu.insertAt(2, {
                         label: 'New Post',
-                        accelerator: 'CmdOrCtrl+Alt+C',
+                        accelerator: 'CmdOrCtrl+N',
                         name: 'open-new-post',
                         click: () => shortcuts.openNewPost()
                     });

--- a/app/styles/components/switcher.css
+++ b/app/styles/components/switcher.css
@@ -31,6 +31,7 @@
 }
 
 .switch-btn {
+    color: #fff;
     position: relative;
     height: 34px;
     width: 34px;

--- a/docs/deeplinks.md
+++ b/docs/deeplinks.md
@@ -6,7 +6,7 @@ Ghost Desktop currently supports the following deeplinks:
 Opens the blog if already registered with the app. If it isn't, it'll open the "Add Blog" UI with the URL prefilled.
 
 ```
-ghost://open-blog/?blog=http://address-of-my-blog.com
+ghost://open-blog/?url=http://address-of-my-blog.com&user=me@ghost.org
 ```
 
 #### Create Draft

--- a/main/open-url.js
+++ b/main/open-url.js
@@ -30,17 +30,17 @@ class OpenUrlManager {
     }
 
     handleOpenBlogUrl(url = '') {
-        const [, rawblogUrl] = url.match(urlMatchers.openBlog);
-        let blogUrl;
+        const [, rawDetails] = url.match(urlMatchers.openBlog);
+        let details;
 
         try {
-            blogUrl = queryString.parse(rawblogUrl);
+            details = queryString.parse(rawDetails);
         } catch (e) {
             return debug('Failed to queryString.parse open-blog url');
         }
 
-        debug(`Received open-blog event with blog url ${blogUrl.blog}`);
-        this.sendToMainWindow('open-blog', blogUrl.blog);
+        debug(`Received open-blog event with blog url ${JSON.stringify(details)}`);
+        this.sendToMainWindow('open-blog', details);
     }
 
     handleCreateDraftUrl(url = '') {


### PR DESCRIPTION
This enables the `ghost://open-blog` deep link to prefill not just the url field, but also the user field.