### PR TITLE
Allow sorting of blogs

### DIFF
--- a/app/components/gh-switcher.js
+++ b/app/components/gh-switcher.js
@@ -15,6 +15,8 @@ export default Component.extend({
     isMinimized: Ember.computed.alias('preferences.isQuickSwitcherMinimized'),
     isMac: !!(process.platform === 'darwin'),
     isVibrant: getIsYosemiteOrHigher(),
+    sortedBlogs: Ember.computed.sort('blogs', 'sortDefinition'),
+    sortDefinition: ['index'],
 
     didRender() {
         this._super(...arguments);
@@ -32,7 +34,7 @@ export default Component.extend({
         let blogMenuItems = [{type: 'separator'}];
 
         // The first 9 blogs are added to the 'View' menu.
-        this.get('blogs')
+        this.get('sortedBlogs')
             .slice(0, 8)
             .map((blog, i) => {
                 blogMenuItems.push({
@@ -53,12 +55,12 @@ export default Component.extend({
      * interaction with the blog below is setup.
      */
     _setupContextMenu() {
-        let {remote} = requireNode('electron');
-        let {Menu} = remote;
-        let self = this;
+        const {remote} = requireNode('electron');
+        const {Menu} = remote;
+        const self = this;
         let selectedBlog = null;
 
-        let editMenu = Menu.buildFromTemplate([
+        const editMenu = Menu.buildFromTemplate([
             {
                 label: 'Edit Blog',
                 click() {
@@ -203,6 +205,21 @@ export default Component.extend({
          */
         toggle() {
             this.toggleProperty('isMinimized');
+        },
+
+        /**
+         * Called by ember-sortable when the order of elements
+         * changes
+         */
+        reorderItems(reorderedBogs) {
+            reorderedBogs.forEach((blog, i) => {
+                blog.set('index', i);
+                console.log(blog, i);
+            });
+
+            this._setupContextMenu();
+            this._setupQuickSwitch();
+            this._setupMenuItem();
         }
     }
 });

--- a/app/models/blog.js
+++ b/app/models/blog.js
@@ -8,6 +8,9 @@ const {Model, attr, hasMany} = DS;
 /*eslint-enable no-unused-vars*/
 
 export default DS.Model.extend({
+    index: attr('number', {
+        defaultValue: 0
+    }),
     name: attr('string'),
     url: attr('string'),
     identification: attr('string'),

--- a/app/styles/components/switcher.css
+++ b/app/styles/components/switcher.css
@@ -91,3 +91,16 @@
     opacity: 0.7;
     box-shadow: none;
 }
+
+.sortable-item {
+  transition: all .125s;
+}
+
+.sortable-item.is-dragging {
+  transition-duration: 0s;
+  z-index: 10;
+}
+
+.sortable-item.is-dropping {
+  z-index: 10;
+}

--- a/app/templates/components/gh-switcher.hbs
+++ b/app/templates/components/gh-switcher.hbs
@@ -1,13 +1,15 @@
-<div class="switcher-blogs">
-    {{#each blogs as |blog index|}}
-        <div class="switcher-blog {{if blog.isSelected "isSelected"}}">
-            <div class="switch-btn" style="background-color:{{blog.iconColor}};" {{action "switchToBlog" blog}} data-blog={{blog.id}}>
-                <span>{{first-letter blog.name}}</span>
+{{#sortable-group tagName="div" class="switcher-blogs" onChange="reorderItems" as |group|}}
+    {{#each sortedBlogs as |blog index|}}
+        {{#sortable-item tagName="div" model=blog group=group handle=".switcher-blog"}}
+            <div class="switcher-blog {{if blog.isSelected "isSelected"}}">
+                <div class="switch-btn" style="background-color:{{blog.iconColor}};" {{action "switchToBlog" blog}} data-blog={{blog.id}}>
+                    <span>{{first-letter blog.name}}</span>
+                </div>
+                <div class="switch-shortcut">{{switch-shortcut index}}</div>
             </div>
-            <div class="switch-shortcut">{{switch-shortcut index}}</div>
-        </div>
+        {{/sortable-item}}
     {{/each}}
-</div>
+{{/sortable-group}}
 <div class="function-buttons">
     <div {{action "showAddBlog"}} class="add-blog-button switch-btn">
         <span>+</span>

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.0",
     "ember-sinon-qunit": "1.3.0",
+    "ember-sortable": "1.9.1",
     "ember-suave": "4.0.0",
     "ember-test-helpers": "^0.5.27",
     "eslint": "^3.5.0",


### PR DESCRIPTION
This PR enables the "sorting" of blogs, meaning that you can drag them around in the switcher. All references and shortcuts will automatically be updated. The macOS dock icon is a notable exception (the order there isn't updated), but I believe that to be just fine :wink:

Closes #237 