### PR TITLE
Retain vibrancy after refresh

### DIFF
--- a/app/utils/window-menu.js
+++ b/app/utils/window-menu.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import ENV from 'ghost-desktop/config/environment';
 
 /**
  * Functions
@@ -12,7 +13,7 @@ import Ember from 'ember';
  * @param {Electron.BrowserWindow} focusedWindow - The currently focussed window
  */
 export function reload(item, focusedWindow) {
-    if (focusedWindow && process.platform !== 'darwin') {
+    if (focusedWindow && (process.platform !== 'darwin' || ENV.environment === 'test')) {
         focusedWindow.reload();
     } else {
         const {ipcRenderer} = require('electron');

--- a/app/utils/window-menu.js
+++ b/app/utils/window-menu.js
@@ -12,8 +12,11 @@ import Ember from 'ember';
  * @param {Electron.BrowserWindow} focusedWindow - The currently focussed window
  */
 export function reload(item, focusedWindow) {
-    if (focusedWindow) {
+    if (focusedWindow && process.platform !== 'darwin') {
         focusedWindow.reload();
+    } else {
+        const {ipcRenderer} = require('electron');
+        ipcRenderer.send('soft-restart-requested', true)
     }
 };
 
@@ -147,9 +150,7 @@ export function setup() {
                      * @param focusedWindow (description)
                      */
                     click(item, focusedWindow) {
-                        if (focusedWindow) {
-                            focusedWindow.reload();
-                        }
+                        reload(item, focusedWindow);
                     }
                 },
                 {

--- a/main/app.js
+++ b/main/app.js
@@ -13,39 +13,35 @@ if (require('./squirrel')()) return;
 
 let mainWindow = null;
 
-function setupListeners() {
+function setupListeners(window) {
     // If a loading operation goes wrong, we'll send Electron back to
     // Ember App entry point
-    mainWindow.webContents.on('did-fail-load', () => mainWindow.loadURL(emberAppLocation));
-    mainWindow.webContents.on('did-finish-load', () => mainWindow.show());
+    window.webContents.on('did-fail-load', () => window.loadURL(emberAppLocation));
+    window.webContents.on('did-finish-load', () => window.show());
 
     // Chromium drag and drop events tend to navigate the app away, making the
     // app impossible to use without restarting. These events should be prevented.
-    mainWindow.webContents.on('will-navigate', (event) => event.preventDefault());
+    window.webContents.on('will-navigate', (event) => event.preventDefault());
 
     if (process.platform === 'darwin') {
-        mainWindow.on('closed', () => {
-            debug('Main window closed, closing application');
-            app.quit();
-        });
-
         app.on('window-all-closed', () => app.quit())
     }
 
-
     // Close stuff a bit harder than usual
     app.on('before-quit', () => {
-        mainWindow.removeAllListeners();
-        mainWindow.close();
+        if (window && !window.isDestroyed()) {
+            window.removeAllListeners();
+            window.close();
 
-        setTimeout(() => app.exit(), 2000);
+            setTimeout(() => app.exit(), 2000);
+        }
     });
 }
 
-function setupWindowProperties() {
+function createMainWindow() {
     const titleBarStyle = (process.platform === 'darwin') ? 'hidden' : 'default';
     const frame = !(process.platform === 'win32');
-    let windowState, usableState, windowStateKeeper;
+    let windowState, usableState, windowStateKeeper, window;
 
     // Instantiate the window with the existing size and position.
     try {
@@ -53,33 +49,56 @@ function setupWindowProperties() {
         usableState = windowState.usableState;
         windowStateKeeper = windowState.windowStateKeeper;
 
-        mainWindow = new BrowserWindow(
+        window = new BrowserWindow(
             Object.assign(usableState, {show: false, titleBarStyle, vibrancy: 'dark', frame})
         );
     } catch (error) {
         // Window state keeper failed, let's still open a window
         debug(`Window state keeper failed: ${error}`);
-        mainWindow = new BrowserWindow({
+        window = new BrowserWindow({
             show: false,
             height: 800,
             width: 1000,
             titleBarStyle,
             vibrancy: 'dark',
+            transparent: (process.platform === 'darwin'),
             frame
         });
     }
 
-    delete mainWindow.module;
+    window.loadURL(emberAppLocation);
+
+    delete window.module;
 
     // Letting the state keeper listen to window resizing and window moving
     // event, and save them accordingly.
-    if (windowStateKeeper) windowStateKeeper.manage(mainWindow);
+    if (windowStateKeeper) windowStateKeeper.manage(window);
+
+    return window;
+}
+
+function reloadMainWindow() {
+    let oldMainWindow;
+
+    if (mainWindow) {
+        oldMainWindow = mainWindow;
+        oldMainWindow.hide();
+    }
+
+    mainWindow = createMainWindow();
+    setupListeners(mainWindow);
+
+    if (oldMainWindow) {
+        // Burn, burn, buuuuurn
+        oldMainWindow.destroy();
+    }
 }
 
 app.on('ready', function onReady() {
     ensureSingleInstance();
-    setupWindowProperties();
     parseArguments();
+
+    mainWindow = createMainWindow();
 
     // Greetings
     if (process.platform === 'win32') {
@@ -90,13 +109,13 @@ app.on('ready', function onReady() {
 
     // If you want to open up dev tools programmatically, call
     // mainWindow.openDevTools();
-    mainWindow.loadURL(emberAppLocation);
+
     state.mainWindowId = mainWindow.id;
 
-    setupListeners();
+    setupListeners(mainWindow);
 
     require('./ipc');
     require('./basic-auth');
 });
 
-module.exports = {mainWindow};
+module.exports = {mainWindow, reloadMainWindow};

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -1,5 +1,6 @@
 const {ipcMain, BrowserWindow} = require('electron');
 const {state} = require('./state-manager');
+const {reloadMainWindow} = require('./app');
 const debug = require('debug-electron')('ghost-desktop:main:ipc');
 
 ipcMain.on('blog-data', (event, data) => {
@@ -34,4 +35,10 @@ ipcMain.on('shutdown-requested', (event) => {
             if (win && !win.isDestroyed()) win.destroy();
         }, 300);
     }
+});
+
+ipcMain.on('soft-restart-requested', () => {
+    debug(`Soft restart requested, closing main window and creating a new one`)
+
+    reloadMainWindow();
 });


### PR DESCRIPTION
Vibrancy (that cool transparency effect on macOS) is lost if the window is reloaded. This is a bug in Electron, but we can work around it by re-creating the browserWindow once a reload is requested.

Closes #242 