### PR TITLE
adjust minimum height to lower screen resolution

### DIFF
--- a/ember-electron/main/app.js
+++ b/ember-electron/main/app.js
@@ -56,7 +56,7 @@ function createMainWindow() {
         debug(`Window state keeper failed: ${error}`);
         window = new BrowserWindow({
             show: false,
-            height: 800,
+            height: 720,
             width: 1000,
             titleBarStyle,
             vibrancy: 'dark',

--- a/ember-electron/main/window-state.js
+++ b/ember-electron/main/window-state.js
@@ -13,7 +13,7 @@ const winStateKeeper = require('electron-window-state');
 function fetchWindowState() {
     const {screen} = electron;
     const defaultWidth = 1000;
-    const defaultHeight = 800;
+    const defaultHeight = 720;
 
     // Instantiate the state keeper with a default state.
     const stateKeeper = winStateKeeper({defaultWidth, defaultHeight});


### PR DESCRIPTION
Hi,

Although the main window itself is resizable but the values of minHeight and minWidth should be reviewed. I'm currently running Ghost Desktop on 1280x800 resolution. Also, a lot of laptops have a native screen resolution of 1366x768 which wouldn't provide enough real-estate to display the Ghost Desktop properly.

Adjusted minimum height down to 720px instead of 800px.

See also [Linux: Main Window not resizable #284](https://github.com/TryGhost/Ghost-Desktop/issues/284)