### PR TITLE
Sync view menu with Ghost admin

### DIFF
--- a/app/services/window-menu.js
+++ b/app/services/window-menu.js
@@ -149,7 +149,7 @@ export default Service.extend({
                         click: () => shortcuts.openSettingsApps()
                     });
                     item.submenu.insertAt(2, {
-                        label: 'Code Injection',
+                        label: 'Code injection',
                         accelerator: 'CmdOrCtrl+Alt+C+I',
                         name: 'open-code-injection',
                         click: () => shortcuts.openSettingsCodeInjection()
@@ -182,13 +182,13 @@ export default Service.extend({
                         click: () => shortcuts.openTeam()
                     });
                     item.submenu.insertAt(2, {
-                        label: 'Content',
-                        accelerator: 'CmdOrCtrl+Alt+C',
+                        label: 'Stories',
+                        accelerator: 'CmdOrCtrl+Alt+S',
                         name: 'open-content',
                         click: () => shortcuts.openContent()
                     });
                     item.submenu.insertAt(2, {
-                        label: 'New Story',
+                        label: 'New story',
                         accelerator: 'CmdOrCtrl+N',
                         name: 'open-new-post',
                         click: () => shortcuts.openNewPost()


### PR DESCRIPTION
Hi @felixrieseberg 

Referring to #289 you said it has been fixed. Unfortunately, it has not been fixed completely in 1.4.0.

![image](https://user-images.githubusercontent.com/7329802/32616920-0a1e4010-c58d-11e7-9b85-5fd95e896fe8.png)

- Content ==> Stories

And some minor capitalisation was still lingering around. This PR puts all menu labels under "View" in sync with the navigation in Ghost Admin. 

Hope that's okay. Cheers, JoKi
