### PR TITLE
Improve window handling (release and close)

### DIFF
--- a/ember-electron/main/app.js
+++ b/ember-electron/main/app.js
@@ -24,7 +24,13 @@ function setupListeners(window) {
     window.webContents.on('will-navigate', (event) => event.preventDefault());
 
     // Once the last window is closed, we'll exit
-    app.on('window-all-closed', () => app.quit());
+    app.on('window-all-closed', () => {
+        // On macOS it is common for applications and their menu bar
+        // to stay active until the user quits explicitly with Cmd + Q
+        if (process.platform !== 'darwin') {
+            app.quit();
+        }
+    });
 
     // Close stuff a bit harder than usual
     app.on('before-quit', () => {
@@ -71,6 +77,14 @@ function createMainWindow() {
         debug(`Window state keeper failed: ${error}`);
         window = new BrowserWindow(defaultOptions);
     }
+
+    // Emitted when the window is closed.
+    window.on('closed', () => {
+        // Dereference the window object, usually you would store windows
+        // in an array if your app supports multi windows, this is the time
+        // when you should delete the corresponding element.
+        window = null;
+    });
 
     window.loadURL(emberAppLocation);
 


### PR DESCRIPTION
Hi @felixrieseberg 

Eventually, this PR might take care of the following issues: #239 and #251 
I already commented it here: https://github.com/TryGhost/Ghost-Desktop/issues/239#issuecomment-322464549

We had similar issues in one of our Electron apps, and using these two code blocks helped to resolve the problem of proper window close and release across Windows, Linux and macOS.

It seems that the behaviour of Ghost Desktop on Windows has been improved already and the `Electron` process(es) are terminated as expected. Eventually, you shall ignore this PR but consider to close the referenced issues.

Please let me know what you think about that.

Thanks and regards, JoKi