### PR TITLE
Change duplicate hotkey (Team vs Tags)

### DIFF
--- a/app/services/window-menu.js
+++ b/app/services/window-menu.js
@@ -177,7 +177,7 @@ export default Service.extend({
                     });
                     item.submenu.insertAt(2, {
                         label: 'Team',
-                        accelerator: 'CmdOrCtrl+Alt+T',
+                        accelerator: 'CmdOrCtrl+Alt+E',
                         name: 'open-team',
                         click: () => shortcuts.openTeam()
                     });


### PR DESCRIPTION
Hi @felixrieseberg 

I just discovered that two menu entries under View have the same hotkey combination:
- Team
- Tags

![image](https://user-images.githubusercontent.com/7329802/32646306-66d4da26-c605-11e7-8ffc-53b101c08300.png)

I took the liberty to change `Team` to `CtrlOrCmd+Alt+E`, as the other letters in `Tags` are already in use. Hope that's okay for everyone.

Cheers, JoKi