### PR TITLE
hotfix to CSS injection at start of the application

### DIFF
--- a/app/components/gh-instance-host.js
+++ b/app/components/gh-instance-host.js
@@ -157,10 +157,12 @@ export default Component.extend({
      */
     _insertCss($webview = this._getWebView()) {
         if ($webview) {
-            // Inject a CSS file for the specific platform (OS X; Windows)
-            injectCss($webview, process.platform);
-            // Inject a CSS file for all platforms (all.css)
-            injectCss($webview, 'all');
+            $webview.addEventListener('dom-ready', () => {
+                // Inject a CSS file for the specific platform (OS X; Windows)
+                injectCss($webview, process.platform);
+                // Inject a CSS file for all platforms (all.css)
+                injectCss($webview, 'all');
+            });
         }
     },
 

--- a/app/utils/inject-css.js
+++ b/app/utils/inject-css.js
@@ -17,9 +17,7 @@ export function injectCss(webview, name = '') {
         }
 
         if (data) {
-            webview.addEventListener('dom-ready', () => {
-                webview.insertCSS(data);
-            });
+            webview.insertCSS(data);
         }
     });
 }

--- a/app/utils/inject-css.js
+++ b/app/utils/inject-css.js
@@ -17,7 +17,9 @@ export function injectCss(webview, name = '') {
         }
 
         if (data) {
-            webview.insertCSS(data);
+            webview.addEventListener('dom-ready', () => {
+                webview.insertCSS(data);
+            });
         }
     });
 }


### PR DESCRIPTION
The problem was the 'webview' wasn't fully loaded so I added an event to check if the dom is loaded before inject the CSS

PR to fit issue #301 

- [x] Commit message has a short title & issue references
- [x] The build will pass (run `npm test`).
