### PR TITLE
fix: Hide spellchecker configuration

### DIFF
--- a/app/components/gh-preferences.js
+++ b/app/components/gh-preferences.js
@@ -13,6 +13,11 @@ export default Component.extend({
     zoomFactor: computed.oneWay('preferences.preferences.zoomFactor'),
     showVibrancy: getIsYosemiteOrHigher(),
 
+    // In Ghost 1.0, an english-only spellchecker was released for the editor
+    // component. Desktop has currently no control over that spellchecker.
+    // For more info, see https://github.com/TryGhost/Ghost-Desktop/issues/307
+    hideSpellcheck: !process.env.GHOST_SHOW_SPELLCHECK_CONFIG,
+
     actions: {
         /**
          * Open a given url in the user's default browser

--- a/app/templates/components/gh-preferences.hbs
+++ b/app/templates/components/gh-preferences.hbs
@@ -48,7 +48,9 @@
                         </label>
                     </div>
                 {{/if}}
-                {{gh-dictionaries-dropdown}}
+                {{#unless hideSpellcheck}}
+                    {{gh-dictionaries-dropdown}}
+                {{/unless}}
                 <div class="form-group">
                     <label for="zoomFactor">Zoom Factor</label>
                     <p>


### PR DESCRIPTION
We're going to temporarily hide the spellchecker configuration until Ghost Admin becomes spellchecker-aware again.

Closes https://github.com/TryGhost/Ghost-Desktop/issues/307